### PR TITLE
Pass compiler flags down to the Tox test environment

### DIFF
--- a/pykern/pksetup.py
+++ b/pykern/pksetup.py
@@ -260,7 +260,7 @@ class Tox(setuptools.Command, object):
 [tox]
 envlist={pyenv}
 [testenv]
-passenv=PKSETUP_PKDEPLOY_IS_DEV
+passenv=PKSETUP_PKDEPLOY_IS_DEV CFLAGS CPPFLAGS LDFLAGS
 deps=-rrequirements.txt
 commands=python setup.py build test
 [testenv:docs]


### PR DESCRIPTION
In order to test a module that contains C/C++ code, it might be necessary to tweak the compilation parameters according to the environment where tox is running. Currently it does not pass compilation flags like `CFLAGS` and the like.

A way to override this manually is:

```
> export TOX_TESTENV_PASSENV='CFLAGS CPPFLAGS LDFLAGS'
> python setup.py tox
```

But I am afraid this hidden and requires people to search for the information. I think we should do the right thing and do not tamper with those environment variables if they have been set for a reason.