### PR TITLE
Fix #99: Relax high constraint for importlib-metadata

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -16,7 +16,7 @@ setup(
         'future>=0.14',
         'github3.py>=1.1',
         # for virtualenv
-        'importlib-metadata<2,>=0.12',
+        'importlib-metadata>=0.12',
         'jinja2>=2.7',
         'psutil>=5.0',
         'py-cpuinfo>=0.2',


### PR DESCRIPTION
In tox 3.21.0 the high constraint for importlib-metadata was relaxed.
https://github.com/tox-dev/tox/pull/1764

A matching PR was also merged in virtualenv.
https://github.com/pypa/virtualenv/pull/2020

So, we no longer need to have a high constraint which should solve the
conflict (importlib-metadata 4.3.0 was installed but we expected <2).