### PR TITLE
Fix radiasoft/sirepo#3732: Update pkresource to search additional packages

### DIFF
--- a/pykern/pkio.py
+++ b/pykern/pkio.py
@@ -5,13 +5,12 @@ u"""Useful I/O operations
 :license: http://www.apache.org/licenses/LICENSE-2.0.html
 """
 from __future__ import absolute_import, division, print_function
+# Root module: Limit imports to  avoid dependency issues
 from pykern import pkconst
 import contextlib
-import copy
 import errno
 import glob
 import io
-import locale
 import os
 import os.path
 import py

--- a/pykern/pkresource.py
+++ b/pykern/pkresource.py
@@ -10,10 +10,8 @@ from __future__ import absolute_import, division, print_function
 import errno
 import glob as builtin_glob
 import importlib
-import inspect
 import os.path
 import pkg_resources
-import re
 
 # TODO(e-carlin): discuss with rn if ok to import pkio
 from pykern import pkinspect

--- a/pykern/pkresource.py
+++ b/pykern/pkresource.py
@@ -42,10 +42,10 @@ def filename(relative_filename, caller_context=None, additional_packages=None, r
                     os.path.join(pkg_resources.resource_filename(p, ''), pksetup.PACKAGE_DATA),
                 ).bestrelpath(pkio.py_path(f)))
             return f
-    msg = f'unable to locate resource={relative_filename} in packages={a}'
+    msg = f'unable to locate in packages={a}'
     if '__main__' in a:
         msg += '; do not call module as a program'
-    raise IOError(errno.ENOENT, msg)
+    raise IOError(errno.ENOENT, msg, relative_filename)
 
 
 def glob(relative_path, caller_context=None, additional_packages=None):

--- a/pykern/pkresource.py
+++ b/pykern/pkresource.py
@@ -71,7 +71,8 @@ def glob_files(relative_path, caller_context=None, packages=None):
 def _files(path, caller_context, packages):
     for p in list(map(
         lambda m: pkinspect.root_package(importlib.import_module(m)),
-        packages or pkinspect.root_package(caller_context if caller_context else pkinspect.caller_module()),
+        packages or \
+            [pkinspect.root_package(caller_context if caller_context else pkinspect.caller_module())],
     )):
         # TODO(e-carlin): using pkg_resources is discouraged
         # https://setuptools.readthedocs.io/en/latest/pkg_resources.html

--- a/pykern/pkresource.py
+++ b/pykern/pkresource.py
@@ -61,8 +61,6 @@ def glob_files(relative_path, caller_context=None, packages=None):
     for f, p in _files(relative_path, caller_context, packages):
         a.append(p)
         res.extend(glob.glob(f))
-    if not res:
-        _raise_no_file_found(a, relative_path)
     return res
 
 

--- a/pykern/pkresource.py
+++ b/pykern/pkresource.py
@@ -8,34 +8,82 @@ from __future__ import absolute_import, division, print_function
 
 # Root module: Import only builtin packages so avoid dependency issues
 import errno
+import glob as builtin_glob
+import importlib
 import inspect
 import os.path
 import pkg_resources
 import re
 
+# TODO(e-carlin): discuss with rn if ok to import pkio
 from pykern import pkinspect
+from pykern import pkio
 from pykern import pksetup
 
 
-def filename(relative_filename, caller_context=None):
+def filename(relative_filename, caller_context=None, additional_packages=None, relpath=False):
     """Return the filename to the resource
 
     Args:
         relative_filename (str): file name relative to package_data directory.
         caller_context (object): Any object from which to get the `root_package`
+        additional_packages (List[str]): Packages to search first in addition to caller_module/caller_context
+        relpath (bool): If True path is relative to package package_data dir
 
     Returns:
-        str: absolute path of the resource file
+        str: absolute or relative (to package_data) path of the resource file
     """
-    pkg = pkinspect.root_package(
-        caller_context if caller_context else pkinspect.caller_module())
     assert not os.path.isabs(relative_filename), \
         'must not be an absolute file name={}'.format(relative_filename)
-    fn = os.path.join(pksetup.PACKAGE_DATA, relative_filename)
-    res = pkg_resources.resource_filename(pkg, fn)
-    if not os.path.exists(res):
-        msg = 'resource does not exist for pkg=' + pkg
-        if pkg == '__main__':
-            msg += '; do not call module as a program'
-        raise IOError((errno.ENOENT, msg, res))
+    a = []
+    for f, p in _files(relative_filename, caller_context, additional_packages):
+        a.append(p)
+        if os.path.exists(f):
+            if relpath:
+                f = str(pkio.py_path(
+                    os.path.join(pkg_resources.resource_filename(p, ''), pksetup.PACKAGE_DATA),
+                ).bestrelpath(pkio.py_path(f)))
+            return f
+    msg = f'unable to locate resource={relative_filename} in packages={a}'
+    if '__main__' in a:
+        msg += '; do not call module as a program'
+    raise IOError(errno.ENOENT, msg)
+
+
+def glob(relative_path, caller_context=None, additional_packages=None):
+    """Find all paths that match the relative path
+
+    Args:
+        relative_path(str): Path relative to package_data directory.
+        caller_context (object): Any object from which to get the `root_package`.
+        additional_packages (List[str]): Packages to search first in addition to caller_module/caller_context
+    Returns:
+        [str]: absolute paths of the matched files
+    """
+    res = []
+    for f, _ in _files(relative_path, caller_context, additional_packages):
+        res.extend(builtin_glob.glob(f))
     return res
+
+
+def _files(path, caller_context, additional_packages):
+    # Search additional_packages first so they can possibly override caller context/module
+    # files of the same name
+    for p in list(map(
+        lambda m: pkinspect.root_package(importlib.import_module(m)),
+        additional_packages or [],
+    )) + [
+        pkinspect.root_package(
+            caller_context if caller_context else pkinspect.caller_module(),
+        )
+    ]:
+        # TODO(e-carlin): using pkg_resources is discouraged
+        # https://setuptools.readthedocs.io/en/latest/pkg_resources.html
+        # But, as of py3.7 importlib.resources doesn't offer a good API
+        # for accessing directories
+        # https://docs.python.org/3/library/importlib.html#module-importlib.resources
+        # https://gitlab.com/python-devs/importlib_resources/-/issues/58
+        yield pkg_resources.resource_filename(
+            p,
+            os.path.join(pksetup.PACKAGE_DATA, path),
+        ), p


### PR DESCRIPTION
Sirepo needs to be able to load resources that live outside of its namespace.
This updates pkresource to support searching for resources beyond the
caller_context / caller_module.

The additional packages are searched first so resources found in them can
override the resources in Sirepo (or any caller context/module).