### PR TITLE
fix #125 walk_tree simplified

### DIFF
--- a/pykern/pkio.py
+++ b/pykern/pkio.py
@@ -285,19 +285,22 @@ def walk_tree(dirname, file_re=None):
     Yields:
         py.path.local: paths in sorted order
     """
-    fr = file_re
-    if fr and not hasattr(fr, 'search'):
-        fr = re.compile(fr)
-    dirname = py_path(dirname).realpath()
-    dn = str(dirname)
+    def _walk(dir_path):
+        for r, _, files in os.walk(str(dir_path), topdown=True, onerror=None, followlinks=False):
+            r = py_path(r)
+            for f in files:
+                yield r.join(f)
+
     res = []
-    for r, d, files in os.walk(dn, topdown=True, onerror=None, followlinks=False):
-        for f in files:
-            p = py_path(r).join(f)
-            if fr and not fr.search(dirname.bestrelpath(p)):
-                continue
-            res.append(p)
-    # Not an iterator, but works as one. Don't assume always will return list
+    d = py_path(dirname)
+    if not file_re:
+        res = list(_walk(d))
+    else:
+        if not hasattr(file_re, 'search'):
+            file_re = re.compile(file_re)
+        for p in _walk(d):
+            if file_re.search(d.bestrelpath(p)):
+                res.append(p)
     return sorted(res)
 
 

--- a/tests/pkio_test.py
+++ b/tests/pkio_test.py
@@ -102,6 +102,7 @@ def test_walk_tree_and_sorted_glob():
     """Looks in work_dir"""
     from pykern import pkunit
     from pykern import pkio
+    import re
 
     with pkunit.save_chdir_work() as pwd:
         for f in ('d1/d7', 'd2/d3', 'd4/d5/d6'):
@@ -115,6 +116,8 @@ def test_walk_tree_and_sorted_glob():
         assert [expect[2]] == list(pkio.walk_tree('.', 'f3')), \
             'When walking tree with file_re, should only return matching files'
         assert [expect[0]] == list(pkio.walk_tree('.', '^d1')), \
+            'When walking tree with file_re, file to match does not include dir being searched'
+        assert [expect[0]] == list(pkio.walk_tree('.', re.compile('^d1'))), \
             'When walking tree with file_re, file to match does not include dir being searched'
         assert pkio.sorted_glob('*/*/f*', key='basename') == expect
 


### PR DESCRIPTION
- Reduced number of local variables
- Hoisted loop invariants
- Simplified no file_re case
- Removed unnecessary comment which can't be enforced