### PR TITLE
Fix #161: pksetup assert versions

### DIFF
--- a/pykern/pkcli/test.py
+++ b/pykern/pkcli/test.py
@@ -90,6 +90,7 @@ def _args(tests):
             a, b = t.split('=')
             if a == 'case':
                 flags.extend(('-k', b))
+            # TODO (gurhar1133): if a == 'skip': skip a certain test
             else:
                 pkcli.command_error('unsupported option={}'.format(t))
         else:

--- a/pykern/pkcli/test.py
+++ b/pykern/pkcli/test.py
@@ -6,6 +6,7 @@ u"""run test files in separate processes
 """
 from __future__ import absolute_import, division, print_function
 from pykern.pkcollections import PKDict
+import pykern.pkcli
 
 
 def default_command(*args):
@@ -27,7 +28,6 @@ def default_command(*args):
     Returns:
         str: passed=N if all passed, else raises `pkcli.Error`
     """
-    from pykern import pkcli
     from pykern import pkconfig
     from pykern import pksubprocess
     from pykern import pkio
@@ -72,13 +72,13 @@ def default_command(*args):
             sys.stdout.write('too many failures={} aborting\n'.format(len(f)))
             break
     if n == 0:
-        pkcli.command_error('no tests found')
+        pykern.pkcli.command_error('no tests found')
     if len(f) > 0:
         # Avoid dumping too many test logs
         for o in f[:5]:
             sys.stdout.write(pkio.read_text(o))
         sys.stdout.flush()
-        pkcli.command_error('FAILED={} passed={}'.format(len(f), n - len(f)))
+        pykern.pkcli.command_error('FAILED={} passed={}'.format(len(f), n - len(f)))
     return 'passed={}'.format(n)
 
 
@@ -90,9 +90,8 @@ def _args(tests):
             a, b = t.split('=')
             if a == 'case':
                 flags.extend(('-k', b))
-            # TODO (gurhar1133): if a == 'skip': skip a certain test
             else:
-                pkcli.command_error('unsupported option={}'.format(t))
+                pykern.pkcli.command_error('unsupported option={}'.format(t))
         else:
             paths.append(t)
     return _find(paths), flags

--- a/pykern/pksetup.py
+++ b/pykern/pksetup.py
@@ -48,7 +48,6 @@ import locale
 import os
 import os.path
 import pkg_resources
-import packaging.version
 import re
 import setuptools
 import setuptools.command.sdist
@@ -343,11 +342,18 @@ def setup(**kwargs):
     Args:
         kwargs: see `setuptools.setup`
     """
-    name = kwargs['name'] # TODO: (gurhar1133): write test (ask rob)
+    def _assert_package_versions():
+        """Raise assertion if another module has installed incompatible version of setuptools
+        """
+        from packaging.version import Version
+
+        assert Version(setuptools.__version__) < Version('57'), \
+            'Some package installed a newer version of setup tools that does not work with pykern.pksetup'
+
+    name = kwargs['name']
     if name != 'pykern':
         # POSIT: setup.py has 'setuptools<57'
-        assert packaging.version.Version(setuptools.__version__) < packaging.version.Version('57'), \
-            'Some package installed a newer version of setup tools that does not work with pykern.pksetup'
+        _assert_package_versions()
     assert type(name) == str, \
         'name must be a str; remove __future__ import unicode_literals in setup.py'
     flags = kwargs['pksetup'] if 'pksetup' in kwargs else {}

--- a/pykern/pksetup.py
+++ b/pykern/pksetup.py
@@ -48,6 +48,7 @@ import locale
 import os
 import os.path
 import pkg_resources
+import packaging.version
 import re
 import setuptools
 import setuptools.command.sdist
@@ -342,7 +343,11 @@ def setup(**kwargs):
     Args:
         kwargs: see `setuptools.setup`
     """
-    name = kwargs['name']
+    name = kwargs['name'] # TODO: (gurhar1133): write test (ask rob)
+    if name != 'pykern':
+        # POSIT: setup.py has 'setuptools<57'
+        assert packaging.version.Version(setuptools.__version__) < packaging.version.Version('57'), \
+            'Some package installed a newer version of setup tools that does not work with pykern.pksetup'
     assert type(name) == str, \
         'name must be a str; remove __future__ import unicode_literals in setup.py'
     flags = kwargs['pksetup'] if 'pksetup' in kwargs else {}

--- a/pykern/pksetup.py
+++ b/pykern/pksetup.py
@@ -344,6 +344,8 @@ def setup(**kwargs):
     """
     def _assert_package_versions():
         """Raise assertion if another module has installed incompatible version of setuptools
+
+        POSIT: setup.py has 'setuptools<57'
         """
         from packaging.version import Version
 
@@ -352,7 +354,6 @@ def setup(**kwargs):
 
     name = kwargs['name']
     if name != 'pykern':
-        # POSIT: setup.py has 'setuptools<57'
         _assert_package_versions()
     assert type(name) == str, \
         'name must be a str; remove __future__ import unicode_literals in setup.py'

--- a/setup.py
+++ b/setup.py
@@ -31,6 +31,7 @@ setup(
         'Sphinx>=1.3.5',
         'twine>=1.9',
         'tox>=1.9',
+        'packaging>=21.0',
         'path.py>=7.7.1',
         'python-dateutil>=2.4.2',
 

--- a/setup.py
+++ b/setup.py
@@ -25,6 +25,7 @@ setup(
         'pytz>=2015.4',
         'ruamel.yaml>=0.16.0',
         'requests>=2.18',
+        # POSIT: pksetup.setup asserts setuptools.__version__ < 57
         'setuptools<57',
         'six>=1.9',
         'Sphinx>=1.3.5',


### PR DESCRIPTION
* _assert_package_versions() ensures setuptools version is correct
* Some imports changed in pkcli/test.py so that unknown options in pykern test invocations throws correct error
