### PR TITLE
fix #165 setuptools 62.1.0 works

### DIFF
--- a/pykern/pksetup.py
+++ b/pykern/pksetup.py
@@ -343,14 +343,14 @@ def setup(**kwargs):
         kwargs: see `setuptools.setup`
     """
     def _assert_package_versions():
-        """Raise assertion if another module has installed incompatible version of setuptools
+        """Raise assertion if another module has installed incompatible versions
 
-        POSIT: setup.py has 'setuptools<57'
+        Currently no incompatible versions that need to be asserted. This
+        commit has an example of how to code this:
+
+        https://git.radiasoft.org/pykern/commit/28c0b69034dd96785964fd7049cc5d33a5c0b9b5
         """
-        from packaging.version import Version
-
-        assert Version(setuptools.__version__) < Version('57'), \
-            'Some package installed a newer version of setup tools that does not work with pykern.pksetup'
+        pass
 
     name = kwargs['name']
     if name != 'pykern':

--- a/setup.py
+++ b/setup.py
@@ -26,7 +26,7 @@ setup(
         'ruamel.yaml>=0.16.0',
         'requests>=2.18',
         # setuptools breaks almost every release so limiting is safer than not
-        'setuptools<63',
+        'setuptools>=62,<63',
         'six>=1.9',
         'Sphinx>=1.3.5',
         'twine>=1.9',

--- a/setup.py
+++ b/setup.py
@@ -25,8 +25,8 @@ setup(
         'pytz>=2015.4',
         'ruamel.yaml>=0.16.0',
         'requests>=2.18',
-        # POSIT: pksetup.setup asserts setuptools.__version__ < 57
-        'setuptools<57',
+        # setuptools breaks almost every release so limiting is safer than not
+        'setuptools<63',
         'six>=1.9',
         'Sphinx>=1.3.5',
         'twine>=1.9',


### PR DESCRIPTION
- [x] Require test?
   - No, implicitly tested
- [x] Security implications?
    - none
- [x] UI changes reviewed?
    - None
- [x] Backwards compatible?
    - Works with python 3.7.2 and 3.10
- [x] Require doc changes?
    - No
- [x] Add [DesignHints](https://github.com/radiasoft/pykern/wiki/DesignHints)?
    - No

