### PR TITLE
Fix #168: recognize if in test dir

### DIFF
--- a/pykern/pkcli/test.py
+++ b/pykern/pkcli/test.py
@@ -100,7 +100,6 @@ def _args(tests):
 
 def _find(paths):
     from pykern import pkio
-
     import re
 
     i = re.compile(r'(?:_work|_data)/')

--- a/pykern/pkcli/test.py
+++ b/pykern/pkcli/test.py
@@ -125,8 +125,4 @@ def _resolve_test_paths(paths, current_dir):
         if p.basename != _SUITE_D:
             p = _SUITE_D
         paths = (p,)
-
-    pkdp('\n\n\n cwd')
-    pkdp('\n\n\n paths: {} \n\n\n', paths)
-
     return paths

--- a/pykern/pkcli/test.py
+++ b/pykern/pkcli/test.py
@@ -6,7 +6,6 @@ u"""run test files in separate processes
 """
 from __future__ import absolute_import, division, print_function
 from pykern.pkcollections import PKDict
-from pykern.pkdebug import pkdp
 import pykern.pkcli
 
 
@@ -14,7 +13,7 @@ def default_command(*args):
     """Run tests one at a time with py.test.
 
     Searches in ``tests`` sub-directory if not provided a
-    list of tests or not in tests/
+    list of tests or not in tests/ already
 
     Arguments are directories or files, which are searched for _test.py
     files.

--- a/pykern/pkcli/test.py
+++ b/pykern/pkcli/test.py
@@ -5,9 +5,11 @@ u"""run test files in separate processes
 :license: http://www.apache.org/licenses/LICENSE-2.0.html
 """
 from __future__ import absolute_import, division, print_function
+from posixpath import pathsep
 from pykern.pkcollections import PKDict
 import pykern.pkcli
 
+_SUITE_D = 'tests'
 
 def default_command(*args):
     """Run tests one at a time with py.test.
@@ -96,20 +98,15 @@ def _args(tests):
             paths.append(t)
     return _find(paths), flags
 
-
 def _find(paths):
     from pykern import pkio
+
     import re
 
     i = re.compile(r'(?:_work|_data)/')
     res = []
     cwd = pkio.py_path()
-    d = paths
-    if cwd.basename == 'tests' and not paths:
-        d = ('.',)
-    elif not paths:
-        d = ('tests',)
-    for t in d:
+    for t in _resolve_test_paths(paths, cwd):
         t = pkio.py_path(t)
         if t.check(file=True):
             res.append(str(cwd.bestrelpath(t)))
@@ -119,3 +116,17 @@ def _find(paths):
             if not i.search(p):
                 res.append(p)
     return res
+
+def _resolve_test_paths(paths, current_dir):
+    from pykern.pkdebug import pkdp
+
+    if not paths:
+        p = current_dir
+        if p.basename != _SUITE_D:
+            p = _SUITE_D
+        paths = (p,)
+
+    pkdp('\n\n\n cwd')
+    pkdp('\n\n\n paths: {} \n\n\n', paths)
+
+    return paths

--- a/pykern/pkcli/test.py
+++ b/pykern/pkcli/test.py
@@ -44,8 +44,6 @@ def default_command(*args):
     f = []
     c = []
     paths, flags = _args(args)
-    pkdp('\n\n\n paths: {} \n\n\n ', paths)
-    pkdp('\n\n\n flags: {} \n\n\n ', flags)
     for t in paths:
         n += 1
         o = t.replace('.py', '.log')
@@ -97,7 +95,6 @@ def _args(tests):
                 pykern.pkcli.command_error('unsupported option={}'.format(t))
         else:
             paths.append(t)
-    pkdp('\n\n paths in _args: {} \n\n', paths)
     return _find(paths), flags
 
 
@@ -108,19 +105,11 @@ def _find(paths):
     i = re.compile(r'(?:_work|_data)/')
     res = []
     cwd = pkio.py_path()
-    pkdp('\n\n cwd.basename in _find: {}', cwd.basename)
-    pkdp('\n\n\n **************')
-    # for test in pkio.walk_tree('.', re.compile(r'_test\.py$')):
-    #     test = str(cwd.bestrelpath(test))
-    #     if not i.search(test):
-    #         pkdp('\n test: {}', test)
     d = paths
     if cwd.basename == 'tests' and not paths:
         d = ('.',)
     elif not paths:
         d = ('tests',)
-
-    pkdp('\n\n\n d is : {}', d)
     for t in d:
         t = pkio.py_path(t)
         if t.check(file=True):

--- a/pykern/pkcli/test.py
+++ b/pykern/pkcli/test.py
@@ -6,6 +6,7 @@ u"""run test files in separate processes
 """
 from __future__ import absolute_import, division, print_function
 from pykern.pkcollections import PKDict
+from pykern.pkdebug import pkdp
 import pykern.pkcli
 
 
@@ -13,7 +14,7 @@ def default_command(*args):
     """Run tests one at a time with py.test.
 
     Searches in ``tests`` sub-directory if not provided a
-    list of tests.
+    list of tests or not in tests/
 
     Arguments are directories or files, which are searched for _test.py
     files.
@@ -43,6 +44,8 @@ def default_command(*args):
     f = []
     c = []
     paths, flags = _args(args)
+    pkdp('\n\n\n paths: {} \n\n\n ', paths)
+    pkdp('\n\n\n flags: {} \n\n\n ', flags)
     for t in paths:
         n += 1
         o = t.replace('.py', '.log')
@@ -94,6 +97,7 @@ def _args(tests):
                 pykern.pkcli.command_error('unsupported option={}'.format(t))
         else:
             paths.append(t)
+    pkdp('\n\n paths in _args: {} \n\n', paths)
     return _find(paths), flags
 
 
@@ -104,7 +108,20 @@ def _find(paths):
     i = re.compile(r'(?:_work|_data)/')
     res = []
     cwd = pkio.py_path()
-    for t in paths or ('tests',):
+    pkdp('\n\n cwd.basename in _find: {}', cwd.basename)
+    pkdp('\n\n\n **************')
+    # for test in pkio.walk_tree('.', re.compile(r'_test\.py$')):
+    #     test = str(cwd.bestrelpath(test))
+    #     if not i.search(test):
+    #         pkdp('\n test: {}', test)
+    d = paths
+    if cwd.basename == 'tests' and not paths:
+        d = ('.',)
+    elif not paths:
+        d = ('tests',)
+
+    pkdp('\n\n\n d is : {}', d)
+    for t in d:
         t = pkio.py_path(t)
         if t.check(file=True):
             res.append(str(cwd.bestrelpath(t)))

--- a/pykern/pkcli/test.py
+++ b/pykern/pkcli/test.py
@@ -5,7 +5,6 @@ u"""run test files in separate processes
 :license: http://www.apache.org/licenses/LICENSE-2.0.html
 """
 from __future__ import absolute_import, division, print_function
-from posixpath import pathsep
 from pykern.pkcollections import PKDict
 import pykern.pkcli
 
@@ -98,6 +97,7 @@ def _args(tests):
             paths.append(t)
     return _find(paths), flags
 
+
 def _find(paths):
     from pykern import pkio
 
@@ -116,6 +116,7 @@ def _find(paths):
             if not i.search(p):
                 res.append(p)
     return res
+
 
 def _resolve_test_paths(paths, current_dir):
     from pykern.pkdebug import pkdp

--- a/tests/pkcli/test_test.py
+++ b/tests/pkcli/test_test.py
@@ -33,3 +33,13 @@ def test_simple(capsys):
         o, e = capsys.readouterr()
         pkunit.pkre('2_test.py FAIL', o)
         pkunit.pkre('x = 1 / 0', o)
+
+def test_tests_dir():
+    from pykern import pkunit
+    from pykern import pkio
+    import pykern.pkcli.test
+
+    with pkio.save_chdir(pkunit.data_dir().join('tests')):
+        with pkunit.pkexcept('FAILED=1 passed=1'):
+            pykern.pkcli.test.default_command()
+        pykern.pkcli.test.default_command('1_test.py')


### PR DESCRIPTION
Now you can run `pykern test` in `tests/` without getting `error: no tests found`

See #167 