### PR TITLE
20220916 Fix #274 use format strings with pkfail

### DIFF
--- a/pykern/pkunit.py
+++ b/pykern/pkunit.py
@@ -551,10 +551,7 @@ to update test data:
             _cmd(), stdout=subprocess.PIPE, stderr=subprocess.STDOUT, text=True
         )
         if p.returncode != 0:
-            pkfail(
-                f"""expect != actual:
-{_failed_msg(p)}""",
-            )
+            pkfail("expect != actual:\n{}", _failed_msg(p))
 
     def _expect_csv(self):
         if not self._expect_path.ext == ".csv":

--- a/tests/pkunit1_data/curly_brackets.in/sample.txt
+++ b/tests/pkunit1_data/curly_brackets.in/sample.txt
@@ -1,0 +1,1 @@
+{unexpected}

--- a/tests/pkunit1_data/curly_brackets.out/sample.txt
+++ b/tests/pkunit1_data/curly_brackets.out/sample.txt
@@ -1,0 +1,1 @@
+expected

--- a/tests/pkunit1_test.py
+++ b/tests/pkunit1_test.py
@@ -25,3 +25,11 @@ def test_case_dirs_deviance():
             with pkunit.ExceptToFile():
                 d.join("in.txt").read()
     pkunit.pkre("not.*found.*deviance-1/in.txt", d.join(pkunit.PKSTACK_PATH).read())
+
+
+def test_case_dirs_curly_brackets():
+    from pykern import pkunit
+
+    with pkunit.pkexcept("1c1\n< expected\n---\n> {unexpected}"):
+        for d in pkunit.case_dirs(group_prefix="curly_brackets"):
+            pass


### PR DESCRIPTION
- [x] Require test?
   - @gurhar1133 please write a deviance test that forces the pkfail message to include `{something}`, e.g. two files one with `{something}` and one with `{not something}`.
- [x] Security implications?
    - none
- [x] UI changes reviewed?
    - none
- [x] Backwards compatible?
    - yes
- [x] Require doc changes?
    - no
- [x] Add [DesignHints](https://github.com/radiasoft/pykern/wiki/DesignHints)?
    - no
