### PR TITLE
fix #185: projex upgrade

### DIFF
--- a/pykern/package_data/projex/projex/__init__.py.jinja
+++ b/pykern/package_data/projex/projex/__init__.py.jinja
@@ -1,13 +1,12 @@
 # -*- coding: utf-8 -*-
-u""":mod:`{{ name }}` package
+""":mod:`{{ name }}` package
 
 {{ copyright_license_rst }}
 """
-from __future__ import absolute_import, division, print_function
 import pkg_resources
 
 try:
     # We only have a version once the package is installed.
-    __version__ = pkg_resources.get_distribution('{{ name }}').version
+    __version__ = pkg_resources.get_distribution("{{ name }}").version
 except pkg_resources.DistributionNotFound:
     pass

--- a/pykern/package_data/projex/projex/projex_console.py.jinja
+++ b/pykern/package_data/projex/projex/projex_console.py.jinja
@@ -1,18 +1,17 @@
 # -*- coding: utf-8 -*-
-u"""Front-end command line for :mod:`{{ name }}`.
+"""Front-end command line for :mod:`{{ name }}`.
 
 See :mod:`pykern.pkcli` for how this module is used.
 
 {{ copyright_license_rst }}
 """
-from __future__ import absolute_import, division, print_function
-from pykern import pkcli
+import pykern.pkcli
 import sys
 
 
 def main():
-    return pkcli.main('{{ name }}')
+    return pykern.pkcli.main("{{ name }}")
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     sys.exit(main())

--- a/pykern/package_data/projex/setup.py.jinja
+++ b/pykern/package_data/projex/setup.py.jinja
@@ -1,29 +1,25 @@
 # -*- coding: utf-8 -*-
-u"""{{ name }} setup script
+"""{{ name }} setup script
 
 {{ copyright_license_rst }}
 """
-from pykern import pksetup
+import pykern.pksetup
 
-pksetup.setup(
-    name='{{ name }}',
-    author='{{ author }}',
-    author_email='{{ author_email }}',
-    description='{{ description }}',
+pykern.pksetup.setup(
+    name="{{ name }}",
+    author="{{ author }}",
+    author_email="{{ author_email }}",
+    description="{{ description }}",
     install_requires=[
-        'pykern',
+        "pykern",
     ],
-    license='{{ license }}',
-    url='{{ url }}',
+    license="{{ license }}",
+    url="{{ url }}",
     classifiers=[
-        'Development Status :: 2 - Pre-Alpha',
-        'Environment :: Console',
-        'Intended Audience :: Developers',
-        '{{ classifier_license }}',
-        'Natural Language :: English',
-        'Programming Language :: Python :: 3',
-        'Programming Language :: Python :: 3.7',
-        'Programming Language :: Python',
-        'Topic :: Utilities',
+        "Development Status :: 2 - Pre-Alpha",
+        "Intended Audience :: Developers",
+        "{{ classifier_license }}",
+        "Programming Language :: Python",
+        "Topic :: Utilities",
     ],
 )

--- a/pykern/package_data/projex/tests/conftest.py.jinja
+++ b/pykern/package_data/projex/tests/conftest.py.jinja
@@ -1,1 +1,1 @@
-pytest_plugins = ['pykern.pytest_plugin']
+pytest_plugins = ["pykern.pytest_plugin"]

--- a/pykern/package_data/projex/tests/import_test.py.jinja
+++ b/pykern/package_data/projex/tests/import_test.py.jinja
@@ -1,12 +1,12 @@
 # -*- coding: utf-8 -*-
-u"""Test that module imports.
+"""Test that module imports.
 
 You should delete the test once you have real tests.
 Only necessary if you have no other tests so that
 tox will work.
 """
-from __future__ import absolute_import, division, print_function
 import pytest
+
 
 def test_1():
     import {{ name }}

--- a/tests/pkcli/projex_test.py
+++ b/tests/pkcli/projex_test.py
@@ -29,7 +29,7 @@ def test_init_rs_tree():
             )
             for expect_fn, expect_re in (
                 ("LICENSE", "Apache License"),
-                ("setup.py", "author='RadiaSoft LLC'"),
+                ("setup.py", 'author="RadiaSoft LLC"'),
             ):
                 assert re.search(
                     expect_re, pkio.read_text(expect_fn)
@@ -65,14 +65,14 @@ def test_init_tree():
                 ("docs/_static/.gitignore", ""),
                 ("docs/_templates/.gitignore", ""),
                 ("docs/index.rst", name),
-                ("setup.py", "author='zauthor'"),
+                ("setup.py", 'author="zauthor"'),
                 ("setup.py", r":copyright:.*zauthor\."),
                 ("tests/.gitignore", "_work"),
                 (name + "/__init__.py", ""),
                 (name + "/package_data/.gitignore", ""),
                 (
                     "{}/{}_console.py".format(name, name),
-                    r"main\('{}'\)".format(name),
+                    r'main\("{}"\)'.format(name),
                 ),
             ):
                 assert re.search(


### PR DESCRIPTION
The 5 classifiers that I kept are the most common across popular projects on PyPi.

New projects with init_tree pass ci. I changed formatting in the jinjas to match the expected output of fmt.