### PR TITLE
fix #329: fmt.diff checks same paths as ci._check_files

### DIFF
--- a/pykern/pkcli/ci.py
+++ b/pykern/pkcli/ci.py
@@ -110,7 +110,7 @@ def run():
     check_eof_newline()
     check_main()
     check_prints()
-    fmt.diff(_paths(pkio.py_path()))
+    fmt.diff(*_paths(pkio.py_path()))
     test.default_command()
 
 

--- a/pykern/pkcli/ci.py
+++ b/pykern/pkcli/ci.py
@@ -110,7 +110,7 @@ def run():
     check_eof_newline()
     check_main()
     check_prints()
-    fmt.diff(pkio.py_path())
+    fmt.diff(_paths(pkio.py_path()))
     test.default_command()
 
 
@@ -121,17 +121,6 @@ def _check_files(case, check_file):
     d = _CHECK_FILES[case]
     r = []
     n = 0
-
-    def _paths(cwd):
-        if pkio.py_path("setup.py").isfile() and (
-            pkio.py_path("README.rst").isfile() or pkio.py_path("README.md").isfile()
-        ):
-            return (
-                cwd.basename,
-                "tests",
-                "setup.py",
-            )
-        return (pkio.py_path(),)
 
     c = pkio.py_path()
     for p in _paths(c):
@@ -147,3 +136,15 @@ def _check_files(case, check_file):
         _error("no files found")
     if r:
         _error("\n".join(r))
+
+
+def _paths(cwd):
+    if pkio.py_path("setup.py").isfile() and (
+        pkio.py_path("README.rst").isfile() or pkio.py_path("README.md").isfile()
+    ):
+        return (
+            cwd.basename,
+            "tests",
+            "setup.py",
+        )
+    return (pkio.py_path(),)

--- a/pykern/pkcli/ci.py
+++ b/pykern/pkcli/ci.py
@@ -139,10 +139,11 @@ def _check_files(case, check_file):
 
 
 def _paths(cwd):
-    if pkio.py_path("setup.py").isfile() and (
-        pkio.py_path("README.rst").isfile() or pkio.py_path("README.md").isfile()
+    if cwd.join("setup.py").isfile() and (
+        cwd.join("README.rst").isfile() or cwd.join("README.md").isfile()
     ):
         return (
+            # POSIT: repo name
             cwd.basename,
             "tests",
             "setup.py",

--- a/pykern/pkcli/ci.py
+++ b/pykern/pkcli/ci.py
@@ -148,4 +148,4 @@ def _paths(cwd):
             "tests",
             "setup.py",
         )
-    return (pkio.py_path(),)
+    return (cwd,)

--- a/pykern/pkcli/fmt.py
+++ b/pykern/pkcli/fmt.py
@@ -37,7 +37,9 @@ def check(*paths):
         _black(paths, "--check")
     except RuntimeError as e:
         if str(e) == "error exit(1)":
-            pykern.pkcli.command_error("paths={} need to be formatted", paths)
+            pykern.pkcli.command_error(
+                "paths={} need to be formatted", tuple(str(p) for p in paths)
+            )
         raise
 
 

--- a/pykern/pkcli/fmt.py
+++ b/pykern/pkcli/fmt.py
@@ -13,7 +13,7 @@ def run(*paths):
     """Run black formatter on `path`
 
     Args:
-        path (object): string or py.path to file or directory
+        *paths (strs or py.paths): strings or py.paths to file or directory
     """
     _black(paths)
 
@@ -22,22 +22,22 @@ def diff(*paths):
     """Run diff on file comparing formatted vs. current file state
 
     Args:
-        path (object): string or py.path to file or directory
+        *paths (strs or py.paths): strings or py.paths to file or directory
     """
     _black(paths, "--diff", "--check", "--no-color")
 
 
-def check(path):
+def check(*paths):
     """Returns True if there would be diff else return False
 
     Args:
-        path (object): string or py.path to file or directory
+        *paths (strs or py.paths): strings or py.paths to file or directory
     """
     try:
-        _black(path, "--check")
+        _black(paths, "--check")
     except RuntimeError as e:
         if str(e) == "error exit(1)":
-            pykern.pkcli.command_error("path={} needs to be formatted", path)
+            pykern.pkcli.command_error("paths={} need to be formatted", paths)
         raise
 
 
@@ -45,6 +45,7 @@ def _black(paths, *args):
     """Helper function invokes black with options
 
     Args:
+         *paths (strs or py.paths): strings or py.paths to file or directory
          *args (strs): options to be passed to black
     """
     from pykern import pkunit

--- a/pykern/pkcli/fmt.py
+++ b/pykern/pkcli/fmt.py
@@ -9,28 +9,22 @@ import py
 import pykern.pksubprocess
 
 
-def run(path):
+def run(*paths):
     """Run black formatter on `path`
 
     Args:
         path (object): string or py.path to file or directory
     """
-    _black(path)
+    _black(paths)
 
 
-def diff(path_or_paths):
-    """Run diff on file comparing formated vs. current file state
+def diff(*paths):
+    """Run diff on file comparing formatted vs. current file state
 
     Args:
         path (object): string or py.path to file or directory
     """
-    for p in (
-        (path_or_paths,)
-        if isinstance(path_or_paths, py._path.local.LocalPath)
-        or isinstance(path_or_paths, str)
-        else path_or_paths
-    ):
-        _black(p, "--diff", "--check", "--no-color")
+    _black(paths, "--diff", "--check", "--no-color")
 
 
 def check(path):
@@ -47,7 +41,7 @@ def check(path):
         raise
 
 
-def _black(path, *args):
+def _black(paths, *args):
     """Helper function invokes black with options
 
     Args:
@@ -64,6 +58,6 @@ def _black(path, *args):
             "--extend-exclude",
             f"/{test.SUITE_D}/.*{pkunit.DATA_DIR_SUFFIX}/|/{pksetup.PACKAGE_DATA}/",
             *args,
-            f"{path}",
+            *paths,
         ],
     )

--- a/pykern/pkcli/fmt.py
+++ b/pykern/pkcli/fmt.py
@@ -5,6 +5,7 @@
 :license: http://www.apache.org/licenses/LICENSE-2.0.html
 """
 from pykern.pkdebug import pkdp, pkdlog
+import py
 import pykern.pksubprocess
 
 
@@ -17,13 +18,19 @@ def run(path):
     _black(path)
 
 
-def diff(path):
+def diff(path_or_paths):
     """Run diff on file comparing formated vs. current file state
 
     Args:
         path (object): string or py.path to file or directory
     """
-    _black(path, "--diff", "--check", "--no-color")
+    for p in (
+        (path_or_paths,)
+        if isinstance(path_or_paths, py._path.local.LocalPath)
+        or isinstance(path_or_paths, str)
+        else path_or_paths
+    ):
+        _black(p, "--diff", "--check", "--no-color")
 
 
 def check(path):

--- a/pykern/pkcli/github.py
+++ b/pykern/pkcli/github.py
@@ -169,7 +169,6 @@ def collaborators(org, filename, affiliation="outside", private=True):
 
 
 def create_issue(repo, title, body="", assignees=None, labels=None, milestone=None):
-
     g = GitHub()
     r = g.repo_arg(repo)
     a = PKDict()

--- a/pykern/xlsx.py
+++ b/pykern/xlsx.py
@@ -482,7 +482,6 @@ class _Cell(_Base):
 
 
 class _Fmt(PKDict):
-
     _MAP = PKDict(
         top=PKDict(top=True),
         bold=PKDict(bold=True),

--- a/setup.py
+++ b/setup.py
@@ -13,7 +13,7 @@ setup(
     author_email="pip@pykern.org",
     install_requires=[
         "argh>=0.26",
-        "black>=22",
+        "black>=22.12",
         "future>=0.14",
         "github3.py>=1.1",
         # for virtualenv

--- a/setup.py
+++ b/setup.py
@@ -13,7 +13,7 @@ setup(
     author_email="pip@pykern.org",
     install_requires=[
         "argh>=0.26",
-        "black==22.12",
+        "black~=22.12",
         "future>=0.14",
         "github3.py>=1.1",
         # for virtualenv

--- a/setup.py
+++ b/setup.py
@@ -13,7 +13,7 @@ setup(
     author_email="pip@pykern.org",
     install_requires=[
         "argh>=0.26",
-        "black>=22.12",
+        "black==22.12",
         "future>=0.14",
         "github3.py>=1.1",
         # for virtualenv

--- a/tests/pkcli/fmt_data/check1.out/pkexcept
+++ b/tests/pkcli/fmt_data/check1.out/pkexcept
@@ -1,1 +1,1 @@
-path=check1 needs to be formatted
+paths=(local('check1'),) need to be formatted

--- a/tests/pkcli/fmt_data/check1.out/pkexcept
+++ b/tests/pkcli/fmt_data/check1.out/pkexcept
@@ -1,1 +1,1 @@
-paths=(local('check1'),) need to be formatted
+paths=('check1',) need to be formatted


### PR DESCRIPTION
The problem I mentioned in today's meeting was in fact [a bug that was fixed](https://github.com/psf/black/issues/2598) in version 22.12.0, and we only required >=22.0 (I was running 22.6.0.)

This update is enforcing new requirements, hence the change to pykern/pkcli/github.py and pykern/xlsx.py.

rshellweg passes ci format checks on my machine with these changes, but running `pykern fmt run .` will change files that `pykern ci run` does not diff. (Running `pykern fmt run .` in rshellweg will format those example files that were failing `pykern ci run`). Do we want `pykern fmt run .` to only run on `<pkg>`, `tests`, `setup.py `when run from the repo root?