### PR TITLE
Fix #350 Add pkunit.restart_or_fail and `$PYKERN_PKCLI_TEST_RESTARTABLE`

### DIFF
--- a/pykern/pkcli/test.py
+++ b/pykern/pkcli/test.py
@@ -16,6 +16,9 @@ SUITE_D = "tests"
 _TEST_PY = re.compile(r"_test\.py$")
 
 
+_cfg = None
+
+
 def default_command(*args):
     """Run tests one at a time with py.test.
 
@@ -40,122 +43,130 @@ def default_command(*args):
         str: passed=N if all passed, else raises `pkcli.Error`
 
     """
-    from pykern import pkconfig
-    from pykern import pksubprocess
-    from pykern.pkcli import fmt
-    from pykern import pkio
-    from pykern import pkunit
-    import os
-    import sys
+    return _Test(args).result
 
-    cfg = pkconfig.init(
-        max_failures=(5, int, "maximum number of test failures before exit"),
-    )
-    e = PKDict(os.environ)
-    n = 0
-    f = []
-    c = []
-    paths, flags = _args(args)
-    for t in paths:
-        n += 1
-        o = t.replace(".py", ".log")
-        _remove_work_dir(t)
-        m = "pass"
-        try:
-            sys.stdout.write(t)
-            sys.stdout.flush()
-            pksubprocess.check_call_with_signals(
-                ["py.test", "--tb=native", "-v", "-s", "-rs", t] + flags,
-                output=o,
-                env=PKDict(
-                    os.environ,
-                ).pkupdate({pkunit.TEST_FILE_ENV: str(pkio.py_path(t))}),
-                # TODO(robnagler) not necessary
-                #                recursive_kill=True,
+
+class _Test:
+    def __init__(self, args):
+        from pykern import pkconfig
+        from pykern import pksubprocess
+        from pykern.pkcli import fmt
+        from pykern import pkio
+        from pykern import pkunit
+        import os
+        import sys
+
+        global _cfg
+        if not _cfg:
+            _cfg = pkconfig.init(
+                max_failures=(5, int, "maximum number of test failures before exit"),
+                max_restarts=(
+                    5,
+                    int,
+                    "maximum number of test restarts before forcing failure",
+                ),
             )
-        except Exception as e:
-            if isinstance(e, RuntimeError) and "exit(5)" in e.args[0]:
-                # 5 means test was skipped
-                # see http://doc.pytest.org/en/latest/usage.html#possible-exit-codes
-                m = "skipped"
+        n = 0
+        f = []
+        c = []
+        self._args(args)
+        for t in self.paths:
+            n += 1
+            o = t.replace(".py", ".log")
+            self._remove_work_dir(t)
+            m = "pass"
+            try:
+                sys.stdout.write(t)
+                sys.stdout.flush()
+                pksubprocess.check_call_with_signals(
+                    ["py.test", "--tb=native", "-v", "-s", "-rs", t] + self.flags,
+                    output=o,
+                    env=PKDict(
+                        os.environ,
+                    ).pkupdate({pkunit.TEST_FILE_ENV: str(pkio.py_path(t))}),
+                )
+            except Exception as e:
+                if isinstance(e, RuntimeError) and "exit(5)" in e.args[0]:
+                    # 5 means test was skipped
+                    # see http://doc.pytest.org/en/latest/usage.html#possible-exit-codes
+                    m = "skipped"
+                else:
+                    m = "FAIL {}".format(o)
+                    f.append(o)
+            sys.stdout.write(" " + m + "\n")
+            if len(f) >= _cfg.max_failures:
+                sys.stdout.write("too many failures={} aborting\n".format(len(f)))
+                break
+        if n == 0:
+            pykern.pkcli.command_error("no tests found")
+        if len(f) > 0:
+            # Avoid dumping too many test logs
+            for o in f[:5]:
+                sys.stdout.write(pkio.read_text(o))
+            sys.stdout.flush()
+            pykern.pkcli.command_error("FAILED={} passed={}".format(len(f), n - len(f)))
+        self.result = "passed={}".format(n)
+
+    def _args(self, tests):
+        def _file(path):
+            if self.skip_past:
+                if self.skip_past in path:
+                    self.skip_past = None
+                return
+            self.paths.append(path)
+
+        def _find(paths):
+            from pykern import pkio
+
+            i = re.compile(r"(?:_work|_data)/")
+            cwd = pkio.py_path()
+            for t in _resolve_test_paths(paths, cwd):
+                t = pkio.py_path(t)
+                if t.check(file=True):
+                    _file(str(cwd.bestrelpath(t)))
+                    continue
+                for p in pkio.walk_tree(t, _TEST_PY):
+                    p = str(cwd.bestrelpath(p))
+                    if not i.search(p):
+                        _file(p)
+
+        def _flag(name, value):
+            if len(value) <= 0:
+                pykern.pkcli.command_error(f"empty value for option={name}")
+            elif name == "case":
+                self.flags.extend(("-k", value))
+            elif name == "skip_past":
+                if self.skip_past:
+                    pykern.pkcli.command_error(
+                        f"skip_past={value} passed twice (skip_past={self.skip_past})"
+                    )
+                self.skip_past = value
             else:
-                m = "FAIL {}".format(o)
-                f.append(o)
-        sys.stdout.write(" " + m + "\n")
-        if len(f) >= cfg.max_failures:
-            sys.stdout.write("too many failures={} aborting\n".format(len(f)))
-            break
-    if n == 0:
-        pykern.pkcli.command_error("no tests found")
-    if len(f) > 0:
-        # Avoid dumping too many test logs
-        for o in f[:5]:
-            sys.stdout.write(pkio.read_text(o))
-        sys.stdout.flush()
-        pykern.pkcli.command_error("FAILED={} passed={}".format(len(f), n - len(f)))
-    return "passed={}".format(n)
+                pykern.pkcli.command_error(f"unsupported option={name}")
 
+        def _resolve_test_paths(paths, current_dir):
+            if not paths:
+                p = current_dir
+                if p.basename != SUITE_D:
+                    p = SUITE_D
+                paths = (p,)
+            return paths
 
-def _args(tests):
-    paths = []
-    flags = []
-    s = None
-    for t in tests:
-        if "=" in t:
-            a, b = t.split("=")
-            if len(b) <= 0:
-                pykern.pkcli.command_error(f"empty value for option={t}")
-            elif a == "case":
-                flags.extend(("-k", b))
-            elif a == "skip_past":
-                s = b
+        paths = []
+        self.flags = []
+        self.skip_past = None
+        for t in tests:
+            if "=" in t:
+                _flag(*(t.split("=")))
             else:
-                pykern.pkcli.command_error(f"unsupported option={t}")
-        else:
-            paths.append(t)
-    return _find(paths, s), flags
+                paths.append(t)
+        self.paths = []
+        _find(paths)
 
+    def _remove_work_dir(self, test_file):
+        from pykern import pkio
+        from pykern import pkunit
 
-def _find(paths, skip_past):
-    from pykern import pkio
-
-    res = []
-
-    def _file(path):
-        nonlocal skip_past
-        if skip_past:
-            if skip_past in path:
-                skip_past = None
-            return
-        res.append(path)
-
-    i = re.compile(r"(?:_work|_data)/")
-    cwd = pkio.py_path()
-    for t in _resolve_test_paths(paths, cwd):
-        t = pkio.py_path(t)
-        if t.check(file=True):
-            _file(str(cwd.bestrelpath(t)))
-            continue
-        for p in pkio.walk_tree(t, _TEST_PY):
-            p = str(cwd.bestrelpath(p))
-            if not i.search(p):
-                _file(p)
-    return res
-
-
-def _remove_work_dir(test_file):
-    from pykern import pkio
-    from pykern import pkunit
-
-    w = _TEST_PY.sub(pkunit.WORK_DIR_SUFFIX, test_file)
-    if w != test_file:
-        pkio.unchecked_remove(w)
-
-
-def _resolve_test_paths(paths, current_dir):
-    if not paths:
-        p = current_dir
-        if p.basename != SUITE_D:
-            p = SUITE_D
-        paths = (p,)
-    return paths
+        w = _TEST_PY.sub(pkunit.WORK_DIR_SUFFIX, test_file)
+        if w != test_file:
+            pkio.unchecked_remove(w)

--- a/pykern/pkunit.py
+++ b/pykern/pkunit.py
@@ -27,7 +27,7 @@ import traceback
 TEST_FILE_ENV = "PYKERN_PKUNIT_TEST_FILE"
 
 #: Environment var set by pykern.pkcli.test if the test is restartable
-TEST_RESTARTABLE = "PYKERN_PKUNIT_TEST_RESTARTABLE"
+RESTARTABLE = "PYKERN_PKUNIT_RESTARTABLE"
 
 #: Where persistent input files are stored (test_base_name_data)
 DATA_DIR_SUFFIX = "_data"
@@ -457,7 +457,7 @@ def restart_or_fail(*args, **kwargs):
         args (tuple): passed to format
         kwargs (dict): passed to format
     """
-    if os.environ.get(TEST_RESTARTABLE):
+    if os.environ.get(RESTARTABLE):
         raise KeyboardInterrupt()
     pkfail(*args, **kwargs)
 

--- a/pykern/pkunit.py
+++ b/pykern/pkunit.py
@@ -26,6 +26,9 @@ import traceback
 #: Environment var set by pykern.pkcli.test for each module under test
 TEST_FILE_ENV = "PYKERN_PKUNIT_TEST_FILE"
 
+#: Environment var set by pykern.pkcli.test if the test is restartable
+TEST_RESTARTABLE = "PYKERN_PKUNIT_TEST_RESTARTABLE"
+
 #: Where persistent input files are stored (test_base_name_data)
 DATA_DIR_SUFFIX = "_data"
 
@@ -439,6 +442,24 @@ def pkre(expect_re, actual, flags=re.IGNORECASE + re.DOTALL):
     """
     if not re.search(expect_re, pkcompat.from_bytes(actual), flags=flags):
         pkfail("expect_re={} != actual={}", expect_re, actual)
+
+
+def restart_or_fail(*args, **kwargs):
+    """Test will be restarted (at process level) if it can, else `pkfail`
+
+    Called by tests which experience known CI failures such
+    as not being able to connect to servers.
+
+    Communicates with pykern.pkcli.test
+
+    Args:
+        fmt (str): to be passed to `string.format`
+        args (tuple): passed to format
+        kwargs (dict): passed to format
+    """
+    if os.environ.get(TEST_RESTARTABLE):
+        raise KeyboardInterrupt()
+    pkfail(*args, **kwargs)
 
 
 def save_chdir_work(is_pkunit_prefix=False, want_empty=True):

--- a/tests/pkcli/test1_data/tests/always_test.py
+++ b/tests/pkcli/test1_data/tests/always_test.py
@@ -1,0 +1,13 @@
+# -*- coding: utf-8 -*-
+"""restarts infinitely
+
+:copyright: Copyright (c) 2019 RadiaSoft LLC.  All Rights Reserved.
+:license: http://www.apache.org/licenses/LICENSE-2.0.html
+"""
+import pytest
+
+
+def test_always():
+    from pykern import pkunit
+
+    pkunit.restart_or_fail("restart infinitely")

--- a/tests/pkcli/test1_data/tests/twice
+++ b/tests/pkcli/test1_data/tests/twice
@@ -1,0 +1,1 @@
+test_twice

--- a/tests/pkcli/test1_data/tests/twice_test.py
+++ b/tests/pkcli/test1_data/tests/twice_test.py
@@ -1,0 +1,20 @@
+# -*- coding: utf-8 -*-
+"""restarts twice
+
+:copyright: Copyright (c) 2019 RadiaSoft LLC.  All Rights Reserved.
+:license: http://www.apache.org/licenses/LICENSE-2.0.html
+"""
+import pytest
+
+
+def test_twice():
+    from pykern import pkunit
+    from pykern import pkio
+    from pykern import pkdebug
+
+    p = pkio.py_path().join("twice")
+    if p.exists():
+        # success
+        return
+    p.write("test_twice")
+    pkunit.restart_or_fail("restart infinitely")

--- a/tests/pkcli/test1_test.py
+++ b/tests/pkcli/test1_test.py
@@ -1,0 +1,22 @@
+# -*- coding: utf-8 -*-
+"""test restartable
+
+:copyright: Copyright (c) 2023 RadiaSoft LLC.  All Rights Reserved.
+:license: http://www.apache.org/licenses/LICENSE-2.0.html
+"""
+import pytest
+
+
+def test_restarable():
+    from pykern import pkconfig
+
+    pkconfig.reset_state_for_testing({"PYKERN_PKCLI_TEST_RESTARTABLE": "1"})
+
+    from pykern import pkio
+    from pykern import pkunit
+    from pykern.pkcli import test
+
+    with pkunit.save_chdir_work() as d:
+        pkunit.data_dir().join("tests").copy(d.join("tests"))
+        with pkunit.pkexcept("FAILED=1 passed=1"):
+            test.default_command()

--- a/tests/pkcli/test1_test.py
+++ b/tests/pkcli/test1_test.py
@@ -8,15 +8,14 @@ import pytest
 
 
 def test_restarable():
-    from pykern import pkconfig
-
-    pkconfig.reset_state_for_testing({"PYKERN_PKCLI_TEST_RESTARTABLE": "1"})
-
     from pykern import pkio
     from pykern import pkunit
     from pykern.pkcli import test
 
-    with pkunit.save_chdir_work() as d:
-        pkunit.data_dir().join("tests").copy(d.join("tests"))
-        with pkunit.pkexcept("FAILED=1 passed=1"):
-            test.default_command()
+    for test._cfg.restartable in (False, True):
+        with pkunit.save_chdir_work() as d:
+            pkunit.data_dir().join("tests").copy(d.join("tests"))
+            with pkunit.pkexcept(
+                "FAILED=1" if test._cfg.restartable else "FAILED=2",
+            ):
+                test.default_command()

--- a/tests/pkcli/test_test.py
+++ b/tests/pkcli/test_test.py
@@ -4,45 +4,45 @@
 :copyright: Copyright (c) 2019 RadiaSoft LLC.  All Rights Reserved.
 :license: http://www.apache.org/licenses/LICENSE-2.0.html
 """
-from __future__ import absolute_import, division, print_function
 import pytest
 
 
 def test_simple(capsys):
     from pykern import pkunit
-    import pykern.pkcli.test
+    from pykern.pkcli import test
 
     with pkunit.save_chdir_work() as d:
         t = d.join("tests")
         pkunit.data_dir().join("tests").copy(t)
         with pkunit.pkexcept("FAILED=1 passed=1"):
-            pykern.pkcli.test.default_command()
+            test.default_command()
         o, e = capsys.readouterr()
         pkunit.pkre("1_test.py pass", o)
         pkunit.pkre("2_test.py FAIL", o)
         t.join("2_test.py").rename(t.join("2_test.py-"))
-        pkunit.pkre("passed=1", pykern.pkcli.test.default_command())
+        pkunit.pkre("passed=1", test.default_command())
         o, e = capsys.readouterr()
         pkunit.pkre("1_test.py pass", o)
-        pkunit.pkre("passed=1", pykern.pkcli.test.default_command("tests/1_test.py"))
+        pkunit.pkre("passed=1", test.default_command("tests/1_test.py"))
         o, e = capsys.readouterr()
         pkunit.pkre("1_test.py pass", o)
         t.join("2_test.py-").rename(t.join("2_test.py"))
         t.join("1_test.py").rename(t.join("1_test.py-"))
         with pkunit.pkexcept("FAILED=1 passed=0"):
-            pykern.pkcli.test.default_command()
+            test.default_command()
         o, e = capsys.readouterr()
         pkunit.pkre("2_test.py FAIL", o)
         pkunit.pkre("x = 1 / 0", o)
 
 
 def test_tests_dir():
+    from pykern import pkio, pkdebug
     from pykern import pkunit
-    from pykern import pkio
-    import pykern.pkcli.test
+    from pykern.pkcli import test
 
-    with pkio.save_chdir(pkunit.data_dir().join("tests")):
+    with pkunit.save_chdir_work() as d:
+        pkunit.data_dir().join("tests").copy(d.join("tests"))
         with pkunit.pkexcept("FAILED=1 passed=1"):
-            pykern.pkcli.test.default_command()
+            test.default_command()
         with pkunit.pkexcept("FAILED=1 passed=0"):
-            pykern.pkcli.test.default_command("skip_past=1_test")
+            test.default_command("skip_past=1_test")


### PR DESCRIPTION
- Refactored pkcli.test to use an instance internally to make state management easier
- Refactored to smaller methods 
