### PR TITLE
Fix #357: set update message before early return

### DIFF
--- a/pykern/pkunit.py
+++ b/pykern/pkunit.py
@@ -651,6 +651,10 @@ the expect jinja template={self._expect_path} manually.
             if self.is_bytes
             else (pkio.read_text, pkio.write_text)
         )
+        self._update_message = f"""
+to update test data:
+        cp '{self._actual_path}' '{self._expect_path}'
+"""
         if self._expect_csv():
             assert not self.is_bytes, "csv is not compatible with is_bytes"
             return
@@ -668,10 +672,6 @@ the expect jinja template={self._expect_path} manually.
             assert not self.is_bytes, "json or jinja is not compatible with is_bytes"
             return
         self._expect_default()
-        self._update_message = f"""
-to update test data:
-        cp '{self._actual_path}' '{self._expect_path}'
-"""
 
     def _validate_args(self, expect_path, *args, **kwargs):
         from pykern.pkcollections import PKDict


### PR DESCRIPTION
`self._update_message` is set earlier in `self._set_expect_and_actual()`

sirepo example works now. Tests pass on pykern and sirepo with this change