### PR TITLE
Fix #368: add --prune to fix broken refs

### DIFF
--- a/pykern/pkcli/github.py
+++ b/pykern/pkcli/github.py
@@ -467,7 +467,11 @@ class _Backup(GitHub):
                 return
             _shell(("cp", "--archive", "--link", str(prev), "./"))
             with pkio.save_chdir(base):
-                _shell(["git", "remote", "update"])
+                l = pkio.py_path("gc.log")
+                if l.check():
+                    pkdlog("gc.log={}", pkio.read_text(l))
+                    pkio.unchecked_remove(l)
+                _shell(["git", "remote", "update", "--prune"])
 
         def _issues():
             def _issue(i, d):


### PR DESCRIPTION
In addition, read gc.log which may have been produced by previous invocations of `git remote update --prune`. --prune runs `git gc` under the covers. Removing the file is needed so the following `git remote update --prune` doesn't produce a warning about the existence of gc.log.