### PR TITLE
Fix #387 pkdebug fmt spec

### DIFF
--- a/pykern/pkdebug.py
+++ b/pykern/pkdebug.py
@@ -80,12 +80,12 @@ value of output is ``$PYKERN_PKDEBUG_OUTPUT``.
 :license: http://www.apache.org/licenses/LICENSE-2.0.html
 
 """
-from __future__ import absolute_import, division, print_function
 from pykern import pkcompat
 from pykern import pkconfig
 from pykern import pkconst
 from pykern import pkinspect
 import datetime
+import decimal
 import functools
 import inspect
 import json
@@ -665,6 +665,11 @@ def _format_arg(obj, depth=0):
                     if depth > 0:
                         return "'" + s + "'"
                     return s
+                if depth <= 0 and isinstance(
+                    obj, (int, complex, float, decimal.Decimal)
+                ):
+                    # allow format string arguments ({.2f}), which only occurs when depth=0
+                    return obj
             s = str(obj)
         # Always truncates a converted string
         return _string(s)

--- a/pykern/pkdebug.py
+++ b/pykern/pkdebug.py
@@ -85,11 +85,11 @@ from pykern import pkconfig
 from pykern import pkconst
 from pykern import pkinspect
 import datetime
-import decimal
 import functools
 import inspect
 import json
 import logging
+import numbers
 import os
 import pprint
 import re
@@ -665,9 +665,7 @@ def _format_arg(obj, depth=0):
                     if depth > 0:
                         return "'" + s + "'"
                     return s
-                if depth <= 0 and isinstance(
-                    obj, (int, complex, float, decimal.Decimal)
-                ):
+                if depth <= 0 and isinstance(obj, numbers.Number):
                     # allow format string arguments ({.2f}), which only occurs when depth=0
                     return obj
             s = str(obj)

--- a/tests/pkcli/projex_test.py
+++ b/tests/pkcli/projex_test.py
@@ -1,10 +1,9 @@
 # -*- coding: utf-8 -*-
 """pytest for `pykern.pkcli.projex`
 
-:copyright: Copyright (c) 2015 Bivio Software, Inc.  All Rights Reserved.
+:copyright: Copyright (c) 2015-2023 RadiaSoft, LLC.  All Rights Reserved.
 :license: http://www.apache.org/licenses/LICENSE-2.0.html
 """
-from __future__ import absolute_import, division, print_function
 import py
 import pytest
 import re
@@ -78,13 +77,3 @@ def test_init_tree():
                 assert re.search(
                     expect_re, pkio.read_text(expect_fn)
                 ), '{} should exist and match "{}"'.format(expect_fn, expect_re)
-            subprocess.check_call(["git", "commit", "-m", "initial"])
-            # Do not install from PyPI
-            pykern_path = py.path.local(__file__).dirpath().dirpath().dirpath()
-            # pykern must be installed for setup.py to be able to be called
-            subprocess.check_call(["pip", "install", "-e", str(pykern_path)])
-            subprocess.check_call(["python", "setup.py", "test"])
-
-
-# TODO(robnagler) get rid of tox
-#            subprocess.check_call(['python', 'setup.py', 'tox'])

--- a/tests/pkdebug2_test.py
+++ b/tests/pkdebug2_test.py
@@ -4,7 +4,6 @@
 :copyright: Copyright (c) 2020 RadiaSoft LLC.  All Rights Reserved.
 :license: http://www.apache.org/licenses/LICENSE-2.0.html
 """
-from __future__ import absolute_import, division, print_function
 
 
 def test_pkdformat():

--- a/tests/pkdebug2_test.py
+++ b/tests/pkdebug2_test.py
@@ -69,3 +69,13 @@ def test_pkdformat():
             return "foo"
 
     _e("foo", T())
+
+
+def test_pkdformat_spec():
+    from pykern import pkdebug, pkunit
+    import decimal
+
+    pkunit.pkeq(
+        "1.23 None 003 01 True",
+        pkdebug.pkdformat("{:.2f} {} {:03d} {:02d} {}", 1.23, None, 3, True, True),
+    )


### PR DESCRIPTION
I removed the running of python setup.py in projex_test.py. It is not something we use, and it was failing weirdly. We need something else which #62 and #37 address.