### PR TITLE
Fix #434 support for radiasoft/sirepo#6636

### DIFF
--- a/pykern/pkdebug.py
+++ b/pykern/pkdebug.py
@@ -174,7 +174,7 @@ def pkdc(fmt, *args, **kwargs):
         _printer._write(fmt, args, kwargs, with_control=True)
 
 
-def pkdexc():
+def pkdexc(exc_info=None):
     """Return last exception and stack as a string
 
     Must be called from an ``except``. This function removes
@@ -191,11 +191,13 @@ def pkdexc():
         except:
             pkdp(pkdexc())
 
+    Args:
+        exc_info (tuple): (type(e), e, traceback) [sys.exc_info]
     Returns:
         str: formatted exception and stack trace
     """
     try:
-        e = sys.exc_info()
+        e = exc_info or sys.exc_info()
         if hasattr(traceback, "TracebackException"):
             return "".join(
                 traceback.format_exception(*e)

--- a/pykern/pkdebug.py
+++ b/pykern/pkdebug.py
@@ -189,7 +189,7 @@ def pkdexc(exc_info=None):
         try:
             something
         except:
-            pkdp(pkdexc())
+            pkdlog("exception={}", pkdexc())
 
     Args:
         exc_info (tuple): (type(e), e, traceback) [sys.exc_info]

--- a/pykern/pkinspect.py
+++ b/pykern/pkinspect.py
@@ -151,6 +151,17 @@ def caller(ignore_modules=None, exclude_first=True):
             del frame
 
 
+def caller_func_name():
+    """Name of function one frame back
+
+    Useful for inter-module dispatch and errors.
+
+    Returns:
+        str: function name
+    """
+    return inspect.currentframe().f_back.f_back.f_code.co_name
+
+
 def caller_module(exclude_first=True):
     """Which module is calling the caller of this function.
 

--- a/pykern/pkio.py
+++ b/pykern/pkio.py
@@ -80,7 +80,9 @@ def compare_files(path1, path2, force=False):
 
 
 def exception_is_not_found(exc):
-    """True if exception is IOError and ENOENT
+    """True if exception is one various file not found errors
+
+    Checks file `FileNotFoundError`, `IO
 
     Args:
         exc (BaseException): to check
@@ -89,7 +91,8 @@ def exception_is_not_found(exc):
         bool: True if is a file not found exception.
     """
     return (
-        isinstance(exc, IOError)
+        isinstance(exc, FileNotFoundError)
+        or isinstance(exc, IOError)
         and exc.errno == errno.ENOENT
         or isinstance(exc, py.error.ENOENT)
     )

--- a/pykern/pkunit.py
+++ b/pykern/pkunit.py
@@ -284,7 +284,7 @@ def file_eq(expect_path, *args, **kwargs):
 
 
 def unbound_localhost_tcp_port(start, stop):
-    """Looks for AF_INET SOCK_STREAM port for which bind fails
+    """Looks for AF_INET SOCK_STREAM port for which bind succeeds
 
     Args:
         start (int): first port

--- a/pykern/pkunit.py
+++ b/pykern/pkunit.py
@@ -298,12 +298,14 @@ def unbound_localhost_tcp_port(start, stop):
             s.bind((LOCALHOST_IP, int(port)))
         return port
 
-    for p in random.sample(range(start, stop), 10):
+    for p in random.sample(range(start, stop), 100):
         try:
             return _check_port(p)
         except Exception:
             pass
-    raise ValueError(f"unable find port in range={start}-{stop} ip={LOCALHOST_IP}")
+    raise ValueError(
+        f"unable find port random sample range={start}-{stop} tries=100 ip={LOCALHOST_IP}"
+    )
 
 
 def is_test_run():

--- a/pykern/pkunit.py
+++ b/pykern/pkunit.py
@@ -18,7 +18,9 @@ import json
 import os
 import py
 import pytest
+import random
 import re
+import socket
 import subprocess
 import sys
 import traceback
@@ -31,6 +33,9 @@ RESTARTABLE = "PYKERN_PKUNIT_RESTARTABLE"
 
 #: Where persistent input files are stored (test_base_name_data)
 DATA_DIR_SUFFIX = "_data"
+
+#: Used to create test servers
+LOCALHOST_IP = "127.0.0.1"
 
 #: Where to write temporary files (test_base_name_work)
 WORK_DIR_SUFFIX = "_work"
@@ -276,6 +281,29 @@ def file_eq(expect_path, *args, **kwargs):
         is_bytes (bool): do a binary comparison [False]
     """
     _FileEq(expect_path, *args, **kwargs)
+
+
+def unbound_localhost_tcp_port(start, stop):
+    """Looks for AF_INET SOCK_STREAM port for which bind fails
+
+    Args:
+        start (int): first port
+        stop (int): one greater than last port (passed to range)
+    Returns:
+        int: port is available or raises ValueError
+    """
+
+    def _check_port(port):
+        with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as s:
+            s.bind((LOCALHOST_IP, int(port)))
+        return port
+
+    for p in random.sample(range(start, stop), 10):
+        try:
+            return _check_port(p)
+        except Exception:
+            pass
+    raise ValueError(f"unable find port in range={start}-{stop} ip={LOCALHOST_IP}")
 
 
 def is_test_run():

--- a/tests/pkasyncio_test.py
+++ b/tests/pkasyncio_test.py
@@ -98,7 +98,7 @@ def _server():
     l.http_server(
         PKDict(
             uri_map=((_URI, _Echo),),
-            tcp_port=pkdebug.pkdp(_PORT),
+            tcp_port=_PORT,
             tcp_ip=pkunit.LOCALHOST_IP,
         )
     )

--- a/tests/pkasyncio_test.py
+++ b/tests/pkasyncio_test.py
@@ -39,10 +39,10 @@ def _client():
     async def _all():
         w = await _open()
         pkdebug.pkdlog("open")
-        await _send(w)
+        await _send(w, "hello")
         pkdebug.pkdlog("send")
-        pkdebug.pkdlog("recv={}", await _recv(w))
-        return
+        pkunit.pkeq("hello", await _recv(w))
+        pkdebug.pkdlog("recv")
 
     async def _open():
         from tornado import httpclient, websocket
@@ -58,8 +58,8 @@ def _client():
     async def _recv(ws):
         return await ws.read_message()
 
-    async def _send(ws):
-        await ws.write_message("hello")
+    async def _send(ws, text):
+        await ws.write_message(text)
 
     asyncio.run(_all())
 
@@ -81,7 +81,8 @@ def _server():
 
     class _Echo(websocket.WebSocketHandler):
         def open(self):
-            pkdebug.pkdlog("port={}", self.request.remote_port)
+            # just to print something
+            pkdebug.pkdlog("remote_ip={}", self.request.remote_ip)
 
         async def on_message(self, msg):
             import asyncio

--- a/tests/pkinspect_test.py
+++ b/tests/pkinspect_test.py
@@ -53,20 +53,23 @@ def test_caller():
     import inspect
     import sys
 
+    def _func_name(expect):
+        pkunit.pkeq(expect, pkinspect.caller_func_name())
+
     m1 = pkunit.import_module_from_data_dir("p1.m1")
     c = m1.caller()
     expect = inspect.currentframe().f_lineno - 1
-    assert expect == c.lineno, "{}: unexpected lineno, should be {}".format(
-        c.lineno, expect
-    )
+    pkunit.pkeq(expect, c.lineno)
     expect = "test_caller"
-    assert expect == c.name, "{}: expected function name {}".format(c.name, expect)
+    pkunit.pkeq(expect, c.name)
+    _func_name(expect)
     this_module = sys.modules[__name__]
     c = m1.caller(ignore_modules=[this_module])
-    assert expect != c.name, "{}: should not be {}".format(c.name, expect)
+    pkunit.pkne(expect, c.name)
     my_caller = pkinspect.caller()
     expect = my_caller._module
-    assert expect == c._module, "{}: should be {}".format(c._module, expect)
+    pkunit.pkeq(expect, c._module)
+    pkunit.pkeq(expect, c._module)
 
 
 def test_caller_module():


### PR DESCRIPTION
- pkdexc accepts exc_info arg
- Add FileNotFound to exception_is_not_found
- add pkinspect.caller_func_name
- added pkunit.unbound_localhost_tcp_port and LOCALHOST_IP