### PR TITLE
Partial #462 remove pkg_resources from pksetup

### DIFF
--- a/pykern/pkcli/test.py
+++ b/pykern/pkcli/test.py
@@ -1,16 +1,15 @@
-# -*- coding: utf-8 -*-
 """run test files in separate processes
 
 :copyright: Copyright (c) 2019 RadiaSoft LLC.  All Rights Reserved.
 :license: http://www.apache.org/licenses/LICENSE-2.0.html
 """
+
 from pykern import pkconfig
 from pykern import pkio
 from pykern import pksubprocess
 from pykern import pkunit
 from pykern.pkcollections import PKDict
 from pykern.pkdebug import pkdp
-import itertools
 import os
 import pykern.pkcli
 import re

--- a/pykern/pkcli/test.py
+++ b/pykern/pkcli/test.py
@@ -180,19 +180,16 @@ class _Test:
         def _ignore_warnings():
             if not _cfg.ignore_warnings:
                 return []
-            return list(
-                # This undoes what pytest does
-                itertools.chain.from_iterable(
-                    ("-W", f"ignore::{w}")
-                    for w in (
-                        # https://docs.python.org/3/library/warnings.html#default-warning-filter
-                        "DeprecationWarning",
-                        "PendingDeprecationWarning",
-                        "ImportWarning",
-                        "ResourceWarning",
-                    )
-                ),
-            )
+            rv = []
+            for w in (
+                # https://docs.python.org/3/library/warnings.html#default-warning-filter
+                "DeprecationWarning",
+                "PendingDeprecationWarning",
+                "ImportWarning",
+                "ResourceWarning",
+            ):
+                rv.extend(("-W", f"ignore::{w}"))
+            return rv
 
         def _try(output, restartable):
             sys.stdout.write(test_f)

--- a/pykern/pkcli/test.py
+++ b/pykern/pkcli/test.py
@@ -180,20 +180,18 @@ class _Test:
         def _ignore_warnings():
             if not _cfg.ignore_warnings:
                 return []
-            return pkdp(
-                list(
-                    # This undoes what pytest does
-                    itertools.chain.from_iterable(
-                        ("-W", f"ignore::{w}")
-                        for w in (
-                            # https://docs.python.org/3/library/warnings.html#default-warning-filter
-                            "DeprecationWarning",
-                            "PendingDeprecationWarning",
-                            "ImportWarning",
-                            "ResourceWarning",
-                        )
-                    ),
-                )
+            return list(
+                # This undoes what pytest does
+                itertools.chain.from_iterable(
+                    ("-W", f"ignore::{w}")
+                    for w in (
+                        # https://docs.python.org/3/library/warnings.html#default-warning-filter
+                        "DeprecationWarning",
+                        "PendingDeprecationWarning",
+                        "ImportWarning",
+                        "ResourceWarning",
+                    )
+                ),
             )
 
         def _try(output, restartable):

--- a/pykern/pkconst.py
+++ b/pykern/pkconst.py
@@ -31,5 +31,8 @@ except Exception:
 #: Copied from numconv, which copied from RFC1924
 BASE62_CHARS = "0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz"
 
+#: The subdirectory in the top-level Python where to put resources
+PACKAGE_DATA = "package_data"
+
 #: Use this (sparingly, pkdlog is prefered) when you want to use print directly.
 builtin_print = print

--- a/pykern/pkresource.py
+++ b/pykern/pkresource.py
@@ -1,22 +1,18 @@
-# -*- coding: utf-8 -*-
 """Where external resources are stored
 
 :copyright: Copyright (c) 2015 Bivio Software, Inc.  All Rights Reserved.
 :license: http://www.apache.org/licenses/LICENSE-2.0.html
 """
-from __future__ import absolute_import, division, print_function
 
-# Root module: Import only builtin packages so avoid dependency issues
+# Root module: avoid importing modules which import pkconfig
+from pykern import pkconst
+from pykern import pkinspect
+from pykern import pkio
 import errno
 import glob
 import importlib
-import os.path
 import pkg_resources
-
-# TODO(e-carlin): discuss with rn if ok to import pkio
-from pykern import pkinspect
-from pykern import pkio
-from pykern import pksetup
+import os.path
 
 
 def file_path(relative_filename, caller_context=None, packages=None):
@@ -89,16 +85,11 @@ def _files(path, caller_context, packages):
             ],
         )
     ):
-        # TODO(e-carlin): using pkg_resources is discouraged
-        # https://setuptools.readthedocs.io/en/latest/pkg_resources.html
-        # But, as of py3.7 importlib.resources doesn't offer a good API
-        # for accessing directories
-        # https://docs.python.org/3/library/importlib.html#module-importlib.resources
-        # https://gitlab.com/python-devs/importlib_resources/-/issues/58
         yield (
+            # Will be fixed in https://github.com/radiasoft/pykern/issues/462
             pkg_resources.resource_filename(
                 p,
-                os.path.join(pksetup.PACKAGE_DATA, path),
+                os.path.join(pkconst.PACKAGE_DATA, path),
             ),
             p,
         )

--- a/pykern/pksetup.py
+++ b/pykern/pksetup.py
@@ -44,7 +44,7 @@ import glob
 import locale
 import os
 import os.path
-import pkg_resources
+import packaging.version
 import re
 import setuptools
 import setuptools.command.sdist
@@ -719,7 +719,7 @@ def _version_float(value):
 def _version_from_datetime(value=None):
     # Avoid 'UserWarning: Normalizing' by setuptools
     return str(
-        pkg_resources.parse_version(
+        packaging.version.Version(
             (value or datetime.datetime.utcnow()).strftime("%Y%m%d.%H%M%S"),
         ),
     )


### PR DESCRIPTION
- Added PYKERN_PKCLI_TEST_IGNORE_WARNINGS=1 to avoid deprecation warnings on tests. These are normally suppressed, but pytest enables all warnings.