### PR TITLE
fix #460: improve error message for fmt diff in ci

### DIFF
--- a/pykern/pkcli/ci.py
+++ b/pykern/pkcli/ci.py
@@ -111,6 +111,9 @@ def run():
     check_eof_newline()
     check_main()
     check_prints()
+    pkdlog(
+        "Checking fmt diff. If a diff is printed below, you can fix this error by running `pykern fmt run .` from the repo root."
+    )
     fmt.diff(*_paths(pkio.py_path()))
     test.default_command()
 

--- a/pykern/pkcli/ci.py
+++ b/pykern/pkcli/ci.py
@@ -112,7 +112,7 @@ def run():
     check_main()
     check_prints()
     pkdlog(
-        "Checking fmt diff. If a diff is printed below, you can fix this error by running `pykern fmt run .` from the repo root."
+        "Checking fmt diff. If a diff is printed below, you can fix this failure by running `pykern fmt run .` from the repo root."
     )
     fmt.diff(*_paths(pkio.py_path()))
     test.default_command()


### PR DESCRIPTION
After the last Black upgrade I received feedback that some scientists were confused about why their tests were failing. ci just prints a diff without any context and fails. I think this message would be helpful. Though, maybe it should only print when there is a diff?