### PR TITLE
Fix #513 pkasyncio protect getpeername better

### DIFF
--- a/pykern/pkasyncio.py
+++ b/pykern/pkasyncio.py
@@ -70,8 +70,10 @@ class Loop:
             # implementation may change; Code in tornado.httputil check connection.
             if c := request.connection:
                 # socket is not set on stream for websockets.
-                if hasattr(c, "stream") and hasattr(c.stream, "socket"):
-                    return "{}:{}".format(*c.stream.socket.getpeername())
+                if getattr(c, "stream", None) and (
+                    s := getattr(c.stream, "socket", None)
+                ):
+                    return "{}:{}".format(*s.getpeername())
             i = request.headers.get("proxy-for", request.remote_ip)
             return f"{i}:0"
 

--- a/pykern/pkdebug.py
+++ b/pykern/pkdebug.py
@@ -280,6 +280,19 @@ def pkdp(fmt_or_arg, *args, **kwargs):
 pkdlog = pkdp
 
 
+def pkdppretty(obj):
+    """Print `obj` using `pkdpretty` and return `obj`
+
+    Args:
+        obj (object): JSON string or python object
+
+    Returns:
+        object: `obj`
+    """
+    pkdp("{}", pkdpretty(obj))
+    return obj
+
+
 def pkdpretty(obj):
     """Return pretty print the object.
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -57,5 +57,8 @@ pykern = "pykern.pykern_console:main"
 [project.urls]
 Homepage = "http://pykern.org"
 
+[tool.setuptools.packages.find]
+include = ["pykern*"]
+
 [tool.setuptools.package-data]
 pykern = ["package_data/**"]


### PR DESCRIPTION
- Saw a case where the connection was there, but the socket was not so getpeername was not found on logging. Fix #512 Add pkdebug.pkdppretty
Fix #514 Add packages.find.include so other dirs get ignored