### PR TITLE
Fix #335 parallelize pkcli.test max_procs=n

### DIFF
--- a/pykern/pkcli/test.py
+++ b/pykern/pkcli/test.py
@@ -42,7 +42,11 @@ _WAIT_LOOP_SLEEP = 0.1
 
 _cfg = pkconfig.init(
     ignore_warnings=(False, bool, "override pytest's output of all warnings"),
-    max_failures=(5, pkconfig.parse_positive_int, "maximum number of test failures before exit"),
+    max_failures=(
+        5,
+        pkconfig.parse_positive_int,
+        "maximum number of test failures before exit",
+    ),
     max_procs=(1, pkconfig.parse_positive_int, "maximum number of parallel test runs"),
     restartable=(
         False,

--- a/pykern/pkcli/test.py
+++ b/pykern/pkcli/test.py
@@ -5,15 +5,18 @@
 """
 
 from pykern import pkconfig
+from pykern import pkconst
 from pykern import pkio
-from pykern import pksubprocess
 from pykern import pkunit
 from pykern.pkcollections import PKDict
 from pykern.pkdebug import pkdp
 import os
 import pykern.pkcli
 import re
+import signal
+import subprocess
 import sys
+import time
 
 
 SUITE_D = "tests"
@@ -23,10 +26,24 @@ _COROUTINE_NEVER_AWAITED = re.compile(
 _TEST_SKIPPED = re.compile(r"^.+\s+SKIPPED\s+\(.+\)$", flags=re.MULTILINE)
 _TEST_PY = re.compile(r"_test\.py$")
 
+_FAIL_MSG = "FAIL"
+
+_PASS_MSG = "pass"
+
+_SKIPPED_MSG = "skipped"
+
+_MAX_RESTARTS = 3
+
+_RESTART_MSG = "restart"
+
+_START_MSG = "start"
+
+_WAIT_LOOP_SLEEP = 0.1
 
 _cfg = pkconfig.init(
     ignore_warnings=(False, bool, "override pytest's output of all warnings"),
-    max_failures=(5, int, "maximum number of test failures before exit"),
+    max_failures=(5, pkconfig.parse_positive_int, "maximum number of test failures before exit"),
+    max_procs=(1, pkconfig.parse_positive_int, "maximum number of parallel test runs"),
     restartable=(
         False,
         bool,
@@ -51,6 +68,9 @@ def default_command(*args):
     files up to and including ``<last_to_ignore>``` (may be partial
     match of the test file).
 
+    ``max_procs=2`` starts two cases simultaneously. Default is 1,
+    or config value `PYKERN_PKCLI_TEST_MAX_PROCS` if set.
+
     Writes failures to ``<base>_test.log``
 
     Args:
@@ -59,26 +79,156 @@ def default_command(*args):
         str: passed=N if all passed, else raises `pkcli.Error`
 
     """
-    return _Test(args).result
+    return _Runner(args).result
 
 
-class _Test:
-    def __init__(self, args):
-        self.count = 0
-        self.failures = []
-        self._args(args)
-        for t in self.paths:
-            self.count += 1
-            self._run_one(t)
-            if len(self.failures) >= _cfg.max_failures:
-                sys.stdout.write(
-                    f"too many failures={len(self.failures)} aborting\n",
+class _Case:
+    def __init__(self, rel_path, runner):
+        super().__init__()
+        self.runner = runner
+        self.rel_path = rel_path
+        self.abs_path = pkio.py_path(rel_path)
+        self.tries = _MAX_RESTARTS if _cfg.restartable else 1
+        self.run()
+
+    def is_done(self, aborting):
+        if (e := self.process.poll()) is None:
+            return None
+        return self._exit(e, aborting)
+
+    def pkdebug_str(self):
+        return f"{self.__class__.__name__}({self.rel_path})"
+
+    def run(self):
+        self.tries -= 1
+        self.restartable = self.tries > 0
+        self.process = self._start()
+
+    def _exit(self, returncode, aborting):
+        def _msg():
+            if 0 == returncode:
+                return _PASS_MSG
+            if 5 == returncode:
+                # 5 means test was skipped
+                # see http://doc.pytest.org/en/latest/usage.html#possible-exit-codes
+                return _SKIPPED_MSG
+            if not aborting and self.restartable and 2 == returncode:
+                # 2 means KeyboardInterrupt
+                # POSIT: pkunit.restart_or_fail uses this
+                return _RESTART_MSG
+            return _FAIL_MSG
+
+        def _skipped(ouput):
+            return _TEST_SKIPPED.findall(ouput)
+
+        self.runner.signal_cascade.processes.remove(self.process)
+        self.process = None
+        o = pkio.read_text(self.output_path)
+        self.skipped = _skipped(o) if _TEST_SKIPPED.search(o) else []
+        if m := re.findall(_COROUTINE_NEVER_AWAITED, o):
+            with self.output_path.open(mode="a") as f:
+                f.write("".join(f"ERROR: {x}\n" for x in m))
+                # never restartable, it's always a defect
+                return _FAIL_MSG
+        self.exit = _msg()
+        return self.exit
+
+    def _start(self):
+        def _env():
+            res = os.environ.copy()
+            res.update(
+                {
+                    pkunit.TEST_FILE_ENV: str(self.abs_path),
+                    pkunit.RESTARTABLE: "1" if self.restartable else "",
+                }
+            )
+            return res
+
+        def _ignore_warnings():
+            if not _cfg.ignore_warnings:
+                return []
+            rv = []
+            for w in (
+                # https://docs.python.org/3/library/warnings.html#default-warning-filter
+                "DeprecationWarning",
+                "PendingDeprecationWarning",
+                "ImportWarning",
+                "ResourceWarning",
+            ):
+                rv.extend(("-W", f"ignore::{w}"))
+            return rv
+
+        def _remove_work_dir():
+            w = _TEST_PY.sub(pkunit.WORK_DIR_SUFFIX, self.rel_path)
+            if w != self.rel_path:
+                pkio.unchecked_remove(w)
+
+        def _process():
+            c = (
+                ["pytest"]
+                + _ignore_warnings()
+                + [
+                    "--tb=native",
+                    "-v",
+                    "-s",
+                    "-rs",
+                    self.rel_path,
+                ]
+                + self.runner.pytest_flags
+            )
+            v = _env()
+            with self.output_path.open("w") as o, open(os.devnull) as i:
+                return subprocess.Popen(
+                    c,
+                    stdin=i,
+                    stdout=o,
+                    stderr=subprocess.STDOUT if o else None,
+                    env=v,
+                    close_fds=True,
                 )
-                break
-        if self.count == 0:
+
+        self.output_path = self.abs_path.new(ext=".log")
+        _remove_work_dir()
+        pkio.unchecked_remove(self.output_path)
+        rv = _process()
+        self.runner.signal_cascade.processes.add(rv)
+        return rv
+
+
+class _Runner:
+    def __init__(self, args):
+
+        def _too_many_failures():
+            if len(self.failures) < _cfg.max_failures:
+                return False
+            self._info(
+                None,
+                [
+                    f"too many failures={len(self.failures)} aborting"
+                    + (
+                        "; waiting for processes to finish"
+                        if self.max_procs > 1 and self.cases
+                        else ""
+                    ),
+                ],
+            )
+
+        self._args(args)
+        if not self.rel_paths:
             pykern.pkcli.command_error("no tests found")
-        self._assert_failures()
-        self.result = f"passed={self.count}"
+        c = 0
+        self.failures = []
+        self.cases = set()
+        with _SignalCascade() as self.signal_cascade:
+            for p in self.rel_paths:
+                c += 1
+                self._run(p)
+                if a := _too_many_failures():
+                    break
+            while self._wait_for_one(aborting=a):
+                pass
+        self._assert_failures(self.failures, c)
+        self.result = f"passed={c}"
 
     def _args(self, tests):
         def _file(path):
@@ -86,13 +236,15 @@ class _Test:
                 if self.skip_past in path:
                     self.skip_past = None
                 return
-            self.paths.append(path)
+            self.rel_paths.append(path)
 
         def _find(paths):
             i = re.compile(r"(?:_work|_data)/")
             cwd = pkio.py_path()
             for t in _resolve_test_paths(paths, cwd):
                 t = pkio.py_path(t)
+                if not t.exists():
+                    pykern.pkcli.command_error("test={} does not exist", t)
                 if t.check(file=True):
                     _file(str(cwd.bestrelpath(t)))
                     continue
@@ -105,7 +257,16 @@ class _Test:
             if len(value) <= 0:
                 pykern.pkcli.command_error(f"empty value for option={name}")
             elif name == "case":
-                self.flags.extend(("-k", value))
+                self.pytest_flags.extend(("-k", value))
+            elif name == "max_procs":
+                try:
+                    self.max_procs = int(value)
+                except Exception:
+                    self.max_procs = -1
+                if self.max_procs <= 0:
+                    pykern.pkcli.command_error(
+                        f"max_procs={value} must be a positive integer"
+                    )
             elif name == "skip_past":
                 if self.skip_past:
                     pykern.pkcli.command_error(
@@ -124,110 +285,103 @@ class _Test:
             return paths
 
         p = []
-        self.flags = []
+        self.pytest_flags = []
+        self.max_procs = _cfg.max_procs
         self.skip_past = None
         for t in tests:
             if "=" in t:
                 _flag(*(t.split("=")))
             else:
                 p.append(t)
-        self.paths = []
+        self.rel_paths = []
         _find(p)
 
-    def _assert_failures(self):
-        if len(self.failures) <= 0:
+    def _assert_failures(self, failures, count):
+        if len(failures) <= 0:
             return
         # Avoid dumping too many test logs
-        for o in self.failures[:5]:
-            sys.stdout.write(pkio.read_text(o))
-        sys.stdout.flush()
+        for c in failures[: _cfg.max_failures]:
+            self._info(None, [pkio.read_text(c.output_path)])
         pykern.pkcli.command_error(
-            f"FAILED={len(self.failures)} passed={self.count - len(self.failures)}",
+            f"FAILED={len(failures)} passed={count - len(failures)}",
         )
 
-    def _remove_work_dir(self, test_file):
-        w = _TEST_PY.sub(pkunit.WORK_DIR_SUFFIX, test_file)
-        if w != test_file:
-            pkio.unchecked_remove(w)
+    def _exit(self, case, msg):
+        if rv := msg != _RESTART_MSG:
+            self.cases.remove(case)
+            if msg == _FAIL_MSG:
+                self.failures.append(case)
+        self._info(case, [msg] + case.skipped)
+        case.skipped = None
+        return rv
 
-    def _run_one(self, test_f):
-        def _env(restartable):
-            res = os.environ.copy()
-            res.update(
-                {
-                    pkunit.TEST_FILE_ENV: str(pkio.py_path(test_f)),
-                    pkunit.RESTARTABLE: "1" if restartable else "",
-                }
-            )
-            return res
+    def _info(self, case, lines):
+        if case is None:
+            if not lines[-1].endswith("\n"):
+                # other output on its own line, ensure newline at end
+                lines[-1] += "\n"
+        else:
+            if lines[0] == _FAIL_MSG:
+                # add the failure context
+                lines[0] += f" {case.output_path}"
+            if self.max_procs > 1:
+                # line by line when multiprocess
+                lines[0] = case.rel_path + " " + lines[0]
+            elif lines[0] == _START_MSG:
+                # starting a case
+                lines[0] = case.rel_path
+            else:
+                # completing a case
+                lines[0] = " " + lines[0]
+                lines[-1] += "\n"
+        o = "\n".join(lines)
+        if self.max_procs > 1 and not o.endswith("\n"):
+            o += "\n"
+        pkconst.builtin_print(o, end="")
+        # TODO(robnagler) is this necessary?
+        sys.stdout.flush()
 
-        def _except(exc, output, restartable):
-            if isinstance(exc, RuntimeError):
-                if "exit(5)" in exc.args[0]:
-                    # 5 means test was skipped
-                    # see http://doc.pytest.org/en/latest/usage.html#possible-exit-codes
-                    return "skipped"
-                if t and "exit(2)" in exc.args[0]:
-                    # 2 means KeyboardInterrupt
-                    # POSIT: pkunit.restart_or_fail uses this
-                    return "restart"
-            return _fail(output)
+    def _run(self, rel_path):
+        c = _Case(rel_path, self)
+        self.cases.add(c)
+        self._info(c, [_START_MSG])
+        if len(self.cases) >= self.max_procs:
+            self._wait_for_one()
 
-        def _fail(output):
-            self.failures.append(output)
-            return f"FAIL {output}"
+    def _wait_for_one(self, aborting=False):
+        while self.cases:
+            for c in self.cases:
+                if (m := c.is_done(aborting)) is None:
+                    continue
+                if self._exit(c, m):
+                    return True
+                c.run()
+            time.sleep(_WAIT_LOOP_SLEEP)
+        return False
 
-        def _ignore_warnings():
-            if not _cfg.ignore_warnings:
-                return []
-            rv = []
-            for w in (
-                # https://docs.python.org/3/library/warnings.html#default-warning-filter
-                "DeprecationWarning",
-                "PendingDeprecationWarning",
-                "ImportWarning",
-                "ResourceWarning",
-            ):
-                rv.extend(("-W", f"ignore::{w}"))
-            return rv
 
-        def _try(output, restartable):
-            sys.stdout.write(test_f)
-            sys.stdout.flush()
-            c = (
-                ["pytest"]
-                + _ignore_warnings()
-                + [
-                    "--tb=native",
-                    "-v",
-                    "-s",
-                    "-rs",
-                    test_f,
-                ]
-                + self.flags
-            )
-            v = _env(restartable)
+class _SignalCascade:
+    _SIGNALS = (signal.SIGTERM, signal.SIGINT)
+    _IGNORE_HANDLERS = frozenset((None, signal.SIG_IGN, signal.SIG_DFL))
+
+    def __init__(self):
+        self.processes = set()
+
+    def __enter__(self):
+        self._prev_handlers = PKDict({s: signal.getsignal(s) for s in self._SIGNALS})
+        for s in self._prev_handlers.keys():
+            signal.signal(s, self._handler)
+        return self
+
+    def __exit__(self, type, value, traceback):
+        for s, h in self._prev_handlers.items():
+            signal.signal(s, h)
+
+    def _handler(self, sig, frame):
+        for p in self.processes:
             try:
-                pksubprocess.check_call_with_signals(c, output=output, env=v)
-            except Exception as e:
-                return _except(e, output, restartable)
-            o = pkio.read_text(output)
-            if m := re.findall(_COROUTINE_NEVER_AWAITED, o):
-                with pkio.py_path(output).open(mode="a") as f:
-                    f.write("".join(f"ERROR: {x}\n" for x in m))
-                return _fail(output)
-            if _TEST_SKIPPED.search(o):
-                return "\n".join(["pass"] + _skipped(o))
-            return "pass"
-
-        def _skipped(ouput):
-            return _TEST_SKIPPED.findall(ouput)
-
-        o = test_f.replace(".py", ".log")
-        for t in range(4 if _cfg.restartable else 0, -1, -1):
-            self._remove_work_dir(test_f)
-            pkio.unchecked_remove(o)
-            m = _try(o, t > 0)
-            sys.stdout.write(" " + m + "\n")
-            if m != "restart":
-                return
+                p.send_signal(sig)
+            except Exception:
+                pass
+        if (h := self._prev_handlers.get(sig)) not in self._IGNORE_HANDLERS:
+            h(sig, frame)

--- a/pykern/pkcli/test.py
+++ b/pykern/pkcli/test.py
@@ -216,6 +216,7 @@ class _Runner:
                     ),
                 ],
             )
+            return True
 
         self._args(args)
         if not self.rel_paths:

--- a/pykern/pkconfig.py
+++ b/pykern/pkconfig.py
@@ -401,6 +401,27 @@ def parse_bytes(value):
     return v
 
 
+def parse_positive_int(value):
+    """Parse is a positive integer
+
+    Args:
+        value (object): to be parsed
+
+    Returns:
+        int: positive value
+    """
+    if isinstance(value, str):
+        try:
+            value = int(value)
+        except Exception as e:
+            raise_error(f"value={value} not an integer; exception={e}")
+    elif not isinstance(value, int):
+        raise_error(f"value={value} must be int or str")
+    if value <= 0:
+        raise_error(f"value={value} must be positive")
+    return value
+
+
 def parse_seconds(value):
     """Parse seconds in `int` or DdH:M:S formats
 
@@ -412,13 +433,13 @@ def parse_seconds(value):
     """
     if isinstance(value, int):
         if value < 0:
-            raise_error("seconds may not be negative value={}".format(value))
+            raise_error(f"seconds may not be negative value={value}")
         return value
     if not isinstance(value, str):
-        raise_error("seconds must be int or str value={}".format(value))
+        raise_error(f"seconds must be int or str value={value}")
     m = _PARSE_SECONDS.search(value)
     if not m or not any(m.groups()):
-        raise_error("seconds must match [Dd][[[H:]M:]S] value={}".format(value))
+        raise_error(f"seconds must match [Dd][[[H:]M:]S] value={value}")
     v = 0
     for x, i in zip((86400, 3600, 60, 1), m.groups()):
         if i is not None:

--- a/test.sh
+++ b/test.sh
@@ -1,0 +1,11 @@
+#!/bin/bash
+#
+# Run pkcli.ci in parallel
+#
+set -euo pipefail
+
+_main() {
+    PYKERN_PKCLI_TEST_MAX_PROCS=4 pykern ci run
+}
+
+_main "$@"

--- a/tests/pkcli/test1_test.py
+++ b/tests/pkcli/test1_test.py
@@ -1,10 +1,8 @@
-# -*- coding: utf-8 -*-
 """test restartable
 
 :copyright: Copyright (c) 2023 RadiaSoft LLC.  All Rights Reserved.
 :license: http://www.apache.org/licenses/LICENSE-2.0.html
 """
-import pytest
 
 
 def test_restarable():
@@ -12,11 +10,13 @@ def test_restarable():
     from pykern import pkunit
     from pykern.pkcli import test
 
+    # ensure does not abort for max_failures (only two tests)
     test._cfg.max_failures = 3
-    for test._cfg.restartable in (False, True):
-        with pkunit.save_chdir_work() as d:
-            pkunit.data_dir().join("tests").copy(d.join("tests"))
-            with pkunit.pkexcept(
-                "FAILED=1" if test._cfg.restartable else "FAILED=2",
-            ):
-                test.default_command()
+    for p in (1, 2, 3):
+        for test._cfg.restartable in (False, True):
+            with pkunit.save_chdir_work() as d:
+                pkunit.data_dir().join("tests").copy(d.join("tests"))
+                with pkunit.pkexcept(
+                    "FAILED=1" if test._cfg.restartable else "FAILED=2",
+                ):
+                    test.default_command(f"max_procs={p}")

--- a/tests/pkcli/test3_data/tests/0slow_test.py
+++ b/tests/pkcli/test3_data/tests/0slow_test.py
@@ -1,0 +1,11 @@
+"""sleeps so other tests can run
+
+:copyright: Copyright (c) 2024 RadiaSoft LLC.  All Rights Reserved.
+:license: http://www.apache.org/licenses/LICENSE-2.0.html
+"""
+
+
+def test_sleep():
+    import time
+
+    time.sleep(1)

--- a/tests/pkcli/test3_data/tests/1fail_test.py
+++ b/tests/pkcli/test3_data/tests/1fail_test.py
@@ -1,0 +1,8 @@
+"""cause a failure which should exit
+
+:copyright: Copyright (c) 2024 RadiaSoft LLC.  All Rights Reserved.
+:license: http://www.apache.org/licenses/LICENSE-2.0.html
+"""
+
+def test_fail():
+    assert 0

--- a/tests/pkcli/test3_data/tests/2pass_test.py
+++ b/tests/pkcli/test3_data/tests/2pass_test.py
@@ -1,0 +1,9 @@
+"""cause a failure which should exit
+
+:copyright: Copyright (c) 2024 RadiaSoft LLC.  All Rights Reserved.
+:license: http://www.apache.org/licenses/LICENSE-2.0.html
+"""
+
+
+def test_pass():
+    pass

--- a/tests/pkcli/test3_test.py
+++ b/tests/pkcli/test3_test.py
@@ -1,0 +1,21 @@
+"""test too many failures with max_procs
+
+:copyright: Copyright (c) 2023 RadiaSoft LLC.  All Rights Reserved.
+:license: http://www.apache.org/licenses/LICENSE-2.0.html
+"""
+
+
+def test_restarable():
+    from pykern import pkio
+    from pykern import pkunit
+    from pykern.pkcli import test
+
+    # force stop on first failure
+    test._cfg.max_failures = 1
+    for p in (1, 2, 3,):
+        with pkunit.save_chdir_work() as d:
+            pkunit.data_dir().join("tests").copy(d.join("tests"))
+            with pkunit.pkexcept(
+                f"FAILED=1 passed={2 if p > 2 else 1}",
+            ):
+                test.default_command(f"max_procs={p}")

--- a/tests/pkcli/test3_test.py
+++ b/tests/pkcli/test3_test.py
@@ -12,7 +12,7 @@ def test_restarable():
 
     # force stop on first failure
     test._cfg.max_failures = 1
-    for p in (1, 2, 3,):
+    for p in (1, 2, 3):
         with pkunit.save_chdir_work() as d:
             pkunit.data_dir().join("tests").copy(d.join("tests"))
             with pkunit.pkexcept(

--- a/tests/pkconfig1_test.py
+++ b/tests/pkconfig1_test.py
@@ -48,6 +48,20 @@ def test_parse_bytes():
     assert 4398046511104 == parse_bytes("004Tb")
 
 
+def test_parse_positive_int():
+    from pykern.pkconfig import parse_positive_int
+    from pykern import pkunit
+
+    pkunit.pkeq(1, parse_positive_int(1))
+    pkunit.pkeq(2, parse_positive_int("2"))
+    with pkunit.pkexcept("int or str"):
+        parse_positive_int(1.0)
+    with pkunit.pkexcept("be positive"):
+        parse_positive_int(0)
+    with pkunit.pkexcept("be positive"):
+        parse_positive_int("-1")
+
+
 def test_parse_seconds():
     from pykern.pkconfig import parse_seconds, parse_secs
 


### PR DESCRIPTION
- Also can configure PYKERN_PKCLI_TEST_MAX_PROCS=n
- Speed up with 10 cores is linear from max_procs1 to 4; 8 didn't seem much improvement
- Add pkconfig.parse_positive_int