### PR TITLE
fix #638 updates for SQLAlchemy 2

### DIFF
--- a/pykern/sql_db.py
+++ b/pykern/sql_db.py
@@ -298,8 +298,8 @@ class _Session:
     def __conn(self):
         if self._conn is None:
             self._conn = self.meta._engine.connect().execution_options(autobegin=False)
-            self._conn.execute(sqlalchemy.text("PRAGMA foreign_keys = ON;"))
             self._txn = self._conn.begin()
+            self._conn.execute(sqlalchemy.text("PRAGMA foreign_keys = ON;"))
         return self._conn
 
     def __execute_table_or_stmt(self, method, table_or_stmt, where):

--- a/pykern/sql_db.py
+++ b/pykern/sql_db.py
@@ -298,8 +298,8 @@ class _Session:
     def __conn(self):
         if self._conn is None:
             self._conn = self.meta._engine.connect()
-            self._conn.execute("PRAGMA foreign_keys = ON;")
             self._txn = self._conn.begin()
+            self._conn.execute(sqlalchemy.text("PRAGMA foreign_keys = ON;"))
         return self._conn
 
     def __execute_table_or_stmt(self, method, table_or_stmt, where):
@@ -374,7 +374,7 @@ class _TableWrap:
         """
         # we do not handle multi column inserted_primary_keys
         if self.has_primary_id and inserted_primary_key is not None:
-            values[self.primary_id] = inserted_primary_key[self.primary_id]
+            values[self.primary_id] = inserted_primary_key._mapping[self.primary_id]
         return values
 
     def fixup_pre_insert(self, session, values):

--- a/pykern/sql_db.py
+++ b/pykern/sql_db.py
@@ -297,9 +297,9 @@ class _Session:
 
     def __conn(self):
         if self._conn is None:
-            self._conn = self.meta._engine.connect()
-            self._txn = self._conn.begin()
+            self._conn = self.meta._engine.connect().execution_options(autobegin=False)
             self._conn.execute(sqlalchemy.text("PRAGMA foreign_keys = ON;"))
+            self._txn = self._conn.begin()
         return self._conn
 
     def __execute_table_or_stmt(self, method, table_or_stmt, where):

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -43,7 +43,7 @@ dependencies = [
     "setuptools>=66",
     "six>=1.9",
     "Sphinx>=1.3.5",
-    "SQLAlchemy>=1.4,<2",
+    "SQLAlchemy==2.0.48",
     "toml>=0.10",
     "tornado",
     "urllib3",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -43,7 +43,7 @@ dependencies = [
     "setuptools>=66",
     "six>=1.9",
     "Sphinx>=1.3.5",
-    "SQLAlchemy==2.0.48",
+    "SQLAlchemy",
     "toml>=0.10",
     "tornado",
     "urllib3",


### PR DESCRIPTION
- wrap raw SQL in `text()` for SA 2 compatibility
- use `execution_options(autobegin=False)` for explicit transactions
- remove `<2` cap on SQLAlchemy dependency