### PR TITLE
fix #644 exclude static/wp_en from check_eof_newline

### DIFF
--- a/pykern/pkcli/ci.py
+++ b/pykern/pkcli/ci.py
@@ -19,7 +19,9 @@ import re
 #: static/js/ext is where Sirepo stores 3rd party library files
 _CHECK_FILES = PKDict(
     check_eof_newline=PKDict(
-        exclude_files=re.compile(r"/static/js/ext/|/static/wp_en/|node_modules/|^run/|^tests/|^venv/"),
+        exclude_files=re.compile(
+            r"/static/js/ext/|/static/wp_en/|node_modules/|^run/|^tests/|^venv/"
+        ),
         include_files=re.compile(r"\.(html|jinja|js|json|md|py|tsx|yml)$"),
     ),
     check_main=PKDict(

--- a/pykern/pkcli/ci.py
+++ b/pykern/pkcli/ci.py
@@ -19,7 +19,7 @@ import re
 #: static/js/ext is where Sirepo stores 3rd party library files
 _CHECK_FILES = PKDict(
     check_eof_newline=PKDict(
-        exclude_files=re.compile(r"/static/js/ext/|node_modules/|^run/|^tests/|^venv/"),
+        exclude_files=re.compile(r"/static/js/ext/|/static/wp_en/|node_modules/|^run/|^tests/|^venv/"),
         include_files=re.compile(r"\.(html|jinja|js|json|md|py|tsx|yml)$"),
     ),
     check_main=PKDict(


### PR DESCRIPTION
- Adds `static/wp_en/` to the `check_eof_newline` exclude pattern alongside the existing `static/js/ext/` exclusion
- `static/wp_en/` contains a scraped static copy of the WordPress site with minified/vendor files that should not be checked for trailing newlines