### PR TITLE
Apply and test sql_db.select for PKDict compatability.

### DIFF
--- a/pykern/sql_db.py
+++ b/pykern/sql_db.py
@@ -266,7 +266,7 @@ class _Session:
         self.commit_or_rollback(commit=False)
 
     def select(self, table_or_stmt, where=None):
-        return self.__execute_table_or_stmt("select", table_or_stmt, where)
+        return self.__execute_table_or_stmt("select", table_or_stmt, where).mappings()
 
     def select_max_primary_id(self, table):
         w = self.meta._table_wrap(table)

--- a/tests/sql_db_test.py
+++ b/tests/sql_db_test.py
@@ -97,9 +97,10 @@ def _selects(meta):
 
     with meta.session() as s:
         r = s.select_one("t1", where=dict(a_name="Mildred"))
-        PKDict(r)
         pkunit.pkeq("hitch hiker's guide", r.a_text)
         t1, t2 = s.t.t1, s.t.t2
+        d = PKDict(r)
+        pkunit.pkeq(t1.c.keys(), list(d.keys()))
         r = s.execute(
             sqlalchemy.select(
                 t1,

--- a/tests/sql_db_test.py
+++ b/tests/sql_db_test.py
@@ -92,10 +92,12 @@ def _meta(dir_path):
 
 def _selects(meta):
     from pykern import pkunit, pkdebug
+    from pykern.pkcollections import PKDict
     import sqlalchemy
 
     with meta.session() as s:
         r = s.select_one("t1", where=dict(a_name="Mildred"))
+        PKDict(r)
         pkunit.pkeq("hitch hiker's guide", r.a_text)
         t1, t2 = s.t.t1, s.t.t2
         r = s.execute(


### PR DESCRIPTION
SQLAlchemy Row objects do not unpack into dictionaries in 2.0 the way they did in 1.4. We often use that unpacking in slicops like this:

```
pkdict(sql_db.select_one(foo))
```

Migration guide suggests appending `.mappings()` to execute here:
https://docs.sqlalchemy.org/en/20/changelog/migration_20.html#result-rows-act-like-named-tuples

See https://github.com/radiasoft/pykern/issues/648